### PR TITLE
fix(*) ensure `clib` outlives object instances created by this library

### DIFF
--- a/lib/resty/router/context.lua
+++ b/lib/resty/router/context.lua
@@ -28,7 +28,9 @@ local clib = cdefs.clib
 function _M.new(schema)
     local context = clib.context_new(schema.schema)
     local c = setmetatable({
-        context = ffi_gc(context, clib.context_free),
+        context = ffi_gc(context, function(c)
+            clib.context_free(c)
+        end),
         schema = schema,
     }, _MT)
 

--- a/lib/resty/router/schema.lua
+++ b/lib/resty/router/schema.lua
@@ -13,9 +13,12 @@ local ffi_gc = ffi.gc
 function _M.new()
     local schema = clib.schema_new()
     local s = setmetatable({
-        schema = ffi_gc(schema, clib.schema_free),
+        schema = ffi_gc(schema, function(s)
+            clib.schema_free(s)
+        end),
         field_types = {},
         field_ctypes = {},
+        clib = clib,
     }, _MT)
 
     return s


### PR DESCRIPTION
to avoid seg faults during GC

Verified with the following example, the bug is no longer present.

```
local schema = require("resty.router.schema")
local router = require("resty.router.router")

local s = schema.new()
local r = router.new(s)


schema = nil
router = nil

rawset(package.loaded, "resty.router.schema", nil)
rawset(package.loaded, "resty.router.router", nil)
rawset(package.loaded, "resty.router.cdefs", nil)

collectgarbage()

s = nil
r = nil

collectgarbage()

print("ok")
```