### PR TITLE
chore(*)move free wrapper into cdefs

### DIFF
--- a/lib/resty/router/cdefs.lua
+++ b/lib/resty/router/cdefs.lua
@@ -137,4 +137,16 @@ end
 return {
     clib = clib,
     ERR_BUF_MAX_LEN = ERR_BUF_MAX_LEN,
+
+    context_free = function(c)
+        clib.context_free(c)
+    end,
+
+    schema_free = function(s)
+        clib.schema_free(s)
+    end,
+
+    router_free = function(r)
+        clib.router_free(r)
+    end,
 }

--- a/lib/resty/router/context.lua
+++ b/lib/resty/router/context.lua
@@ -23,14 +23,13 @@ local CACHED_VALUE = ffi_new("CValue[1]")
 local UUID_BUF = ffi_new("uint8_t[?]", UUID_LEN)
 local ERR_BUF_MAX_LEN = cdefs.ERR_BUF_MAX_LEN
 local clib = cdefs.clib
+local context_free = cdefs.context_free
 
 
 function _M.new(schema)
     local context = clib.context_new(schema.schema)
     local c = setmetatable({
-        context = ffi_gc(context, function(c)
-            clib.context_free(c)
-        end),
+        context = ffi_gc(context, context_free),
         schema = schema,
     }, _MT)
 

--- a/lib/resty/router/router.lua
+++ b/lib/resty/router/router.lua
@@ -17,6 +17,7 @@ local setmetatable = setmetatable
 
 local ERR_BUF_MAX_LEN = cdefs.ERR_BUF_MAX_LEN
 local clib = cdefs.clib
+local router_free = cdefs.router_free
 
 
 function _M.new(schema)
@@ -29,9 +30,7 @@ function _M.new(schema)
     -- causing instruction fetch faults because the `router` finalizer will
     -- attempt to execute from unmapped memory region
     local r = setmetatable({
-        router = ffi_gc(router, function(r)
-            clib.router_free(r)
-        end),
+        router = ffi_gc(router, router_free),
         schema = schema,
         priorities = {},
     }, _MT)

--- a/lib/resty/router/schema.lua
+++ b/lib/resty/router/schema.lua
@@ -8,14 +8,13 @@ local _MT = { __index = _M, }
 
 local setmetatable = setmetatable
 local ffi_gc = ffi.gc
+local schema_free = cdefs.schema_free
 
 
 function _M.new()
     local schema = clib.schema_new()
     local s = setmetatable({
-        schema = ffi_gc(schema, function(s)
-            clib.schema_free(s)
-        end),
+        schema = ffi_gc(schema, schema_free),
         field_types = {},
         field_ctypes = {},
         clib = clib,

--- a/lib/resty/router/schema.lua
+++ b/lib/resty/router/schema.lua
@@ -1,5 +1,5 @@
 local _M = {}
-local clib = require("resty.router.cdefs").clib
+local cdefs = require("resty.router.cdefs")
 local ffi = require("ffi")
 
 
@@ -8,6 +8,7 @@ local _MT = { __index = _M, }
 
 local setmetatable = setmetatable
 local ffi_gc = ffi.gc
+local clib = cdefs.clib
 local schema_free = cdefs.schema_free
 
 

--- a/t/02-gc.t
+++ b/t/02-gc.t
@@ -1,0 +1,62 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(2);
+
+plan tests => repeat_each() * blocks() * 5;
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_package_cpath "$pwd/target/debug/?.so;;";
+};
+
+no_long_string();
+no_diff();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: gc schema, router
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local schema = require("resty.router.schema")
+            local router = require("resty.router.router")
+
+            local s = schema.new()
+            local r = router.new(s)
+
+            schema = nil
+            router = nil
+
+            rawset(package.loaded, "resty.router.schema", nil)
+            rawset(package.loaded, "resty.router.router", nil)
+            rawset(package.loaded, "resty.router.cdefs", nil)
+
+            collectgarbage()
+
+            s = nil
+            r = nil
+
+            collectgarbage()
+
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- no_error_log
+[error]
+[warn]
+[crit]
+
+
+

--- a/t/02-gc.t
+++ b/t/02-gc.t
@@ -3,7 +3,7 @@
 use Test::Nginx::Socket::Lua;
 use Cwd qw(cwd);
 
-repeat_each(2);
+repeat_each(1);
 
 plan tests => repeat_each() * blocks() * 5;
 


### PR DESCRIPTION
I moved anonymous free functions into `cdefs`,
I think it will make the code more clean and readable.

Does it make sense?