### PR TITLE
fix(*) do not use  to check if the cargo binary is installed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ all: ;
 build: target/release/libatc_router.so
 
 target/release/libatc_router.so: src/*.rs
-ifeq (, $(shell which cargo))
+ifeq (, $(shell cargo))
 $(error "cargo not found in PATH, consider doing \"curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh\"")
 endif
 	cargo build --release


### PR DESCRIPTION
`which` is causing issues when building on some OS because that command is not found. (e.g. amazonlinux). we are getting the same check result with `ifeq (, $(shell cargo))`