### PR TITLE
fix(cdefs) atc router lib loading triggers some weird luajit bug

### DIFF
--- a/lib/resty/router/cdefs.lua
+++ b/lib/resty/router/cdefs.lua
@@ -95,6 +95,7 @@ local ERR_BUF_MAX_LEN = 2048
 -- From: https://github.com/openresty/lua-resty-signal/blob/master/lib/resty/signal.lua
 local load_shared_lib
 do
+    local tostring = tostring
     local string_gmatch = string.gmatch
     local string_match = string.match
     local io_open = io.open
@@ -108,7 +109,7 @@ do
         local i = 1
 
         for k, _ in string_gmatch(cpath, "[^;]+") do
-            local fpath = string_match(k, "(.*/)")
+            local fpath = tostring(string_match(k, "(.*/)"))
             fpath = fpath .. so_name
             -- Don't get me wrong, the only way to know if a file exist is
             -- trying to open it.


### PR DESCRIPTION
### Summary

On my M1 mac the `load_shared_lib` function does not work.

 I have a weird thing happening with ATC router .so loading on my mac,  basically this code in `resty/router/cdefs.lua` causes an issue:
```
            local fpath = string_match(k, "(.*/)")
            fpath = fpath .. so_name
```

it errors with:
```
resty/router/cdefs.lua:112: attempt to concatenate local 'fpath' (a nil value)
```

If I print the `fpath` it gives me `string` value back, if I `print(type(fpath))` it prints `string` but in concatenation it still acts as a `nil`. Thus I was thinking that could there be strange things happening with `metatables`. The `metatable` for `fpath` is:
```
{
  __index = {
    byte = <function 1>,
    char = <function 2>,
    dump = <function 3>,
    find = <function 4>,
    format = <function 5>,
    gmatch = <function 6>,
    gsub = <function 7>,
    len = <function 8>,
    lower = <function 9>,
    match = <function 10>,
    rep = <function 11>,
    reverse = <function 12>,
    sub = <function 13>,
    upper = <function 14>
  }
}
{
  __index = {
    byte = <function 1>,
    char = <function 2>,
    dump = <function 3>,
    find = <function 4>,
    format = <function 5>,
    gmatch = <function 6>,
    gsub = <function 7>,
    len = <function 8>,
    lower = <function 9>,
    match = <function 10>,
    rep = <function 11>,
    reverse = <function 12>,
    sub = <function 13>,
    upper = <function 14>
  }
}
```

which I think looks fine. But this gets more interesting as I also can get it working with a simple change on line:
```
local fpath = string_match(k, "(.*/)")
```

and change that to:

```
local fpath = tostring(string_match(k, "(.*/)"))
```

Then everything seems to work as expected. So I believe it may be some weird bug in OpenResty LuaJIT or upstream LuaJIT, but I am not sure.