### PR TITLE
feat(releases): setup automated releases

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,20 @@
+# Please see the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+# https://github.com/rust-lang/rust-semverver/blob/541a462d36c22cf6f82173099dab85ff108570d6/.github/dependabot.yml
+
+version: 2
+updates:
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    ignore:
+        # These are peer deps of Cargo and should not be automatically bumped
+        - dependency-name: "semver"
+        - dependency-name: "crates-io"
+    rebase-strategy: "disabled"
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: daily

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -1,0 +1,58 @@
+---
+name: Release
+
+on:  # yamllint disable-line rule:truthy
+  pull_request:
+  push:
+    branches:
+    - main
+
+env:
+  DESTDIR: /tmp/build
+
+jobs:
+  release:
+    name: Create Release
+    runs-on: ubuntu-latest
+    outputs:
+      published: ${{ steps.release.outputs.published }}
+      release-git-tag: ${{ steps.release.outputs.release-git-tag }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+    - name: Release
+      id: release
+      uses: ahmadnassri/action-semantic-release@v2.1.10
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  artifacts:
+    needs: release
+    name: Create Release Artifacts
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        target:
+          - x86_64-unknown-linux-gnu
+          - x86_64-unknown-linux-musl
+          - aarch64-unknown-linux-gnu
+          - aarch64-unknown-linux-musl
+    steps:
+    - uses: actions/checkout@v3
+    - uses: actions-rs/toolchain@v1
+      with:
+        toolchain: stable
+        target: ${{ matrix.target }}
+        override: true
+    - name: Build & Install
+      run: |
+        make install
+    - name: Compress and rename artifacts
+      run: tar -C /tmp/build/ -czvf ${{ matrix.target }}.tar.gz .
+    - name: Add Release Artifacts to the Github Release
+      if: ${{ needs.release.outputs.published }} == 'true'
+      uses: softprops/action-gh-release@v1
+      with:
+        tag_name: ${{ needs.release.outputs.release-git-tag }}
+        files: ${{ matrix.target }}.tar.gz
+

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,6 +9,7 @@ on:  # yamllint disable-line rule:truthy
 
 env:
   DESTDIR: /tmp/build
+  LUA_LIB_DIR: /usr/local/openresty/lualib
 
 jobs:
   release:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -50,7 +50,7 @@ jobs:
     - name: Compress and rename artifacts
       run: tar -C /tmp/build/ -czvf ${{ matrix.target }}.tar.gz .
     - name: Add Release Artifacts to the Github Release
-      if: ${{ needs.release.outputs.published }} == 'true'
+      if: ${{ needs.release.outputs.published == 'true' }}
       uses: softprops/action-gh-release@v1
       with:
         tag_name: ${{ needs.release.outputs.release-git-tag }}

--- a/.releaserc
+++ b/.releaserc
@@ -1,0 +1,45 @@
+{
+  "branches": ["main"],
+  "tagFormat": "${version}",
+  "repositoryUrl": "https://github.com/hutchic/atc-router.git",
+  "plugins": [
+    [
+      "@semantic-release/commit-analyzer",
+      {
+        "preset": "conventionalcommits",
+        "releaseRules": [
+          { "breaking": true, "release": "major" },
+          { "revert": true, "release": "patch" },
+          { "type": "build", "release": "patch" },
+          { "type": "docs", "release": "patch" },
+          { "type": "feat", "release": "minor" },
+          { "type": "fix", "release": "patch" },
+          { "type": "perf", "release": "patch" },
+          { "type": "refactor", "release": "patch" },
+          { "type": "chore", "release": "patch" }
+        ]
+      }
+    ],
+    [
+      "@semantic-release/release-notes-generator",
+      {
+        "preset": "conventionalcommits",
+        "presetConfig": {
+          "types": [
+            { "type": "build", "section": "Build", "hidden": false },
+            { "type": "chore", "section": "Chores", "hidden": false },
+            { "type": "ci", "section": "CI/CD", "hidden": false },
+            { "type": "docs", "section": "Docs", "hidden": false },
+            { "type": "feat", "section": "Features", "hidden": false },
+            { "type": "fix", "section": "Bug Fixes", "hidden": false },
+            { "type": "perf", "section": "Performance", "hidden": false },
+            { "type": "refactor", "section": "Refactor", "hidden": false },
+            { "type": "style", "section": "Code Style", "hidden": false },
+            { "type": "test", "section": "Tests", "hidden": false }
+          ]
+        }
+      }
+    ],
+    "@semantic-release/github"
+  ]
+}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+export SHELL:=/bin/bash
+
 OS=$(shell uname -s)
 
 ifeq ($(OS), Darwin)
@@ -14,6 +16,9 @@ LUA_INCLUDE_DIR ?= $(PREFIX)/include
 LUA_LIB_DIR ?=     $(PREFIX)/lib/lua/$(LUA_VERSION)
 INSTALL ?= install
 
+CARGO := $(HOME)/.cargo/bin/cargo
+TARGET := x86_64-unknown-linux-gnu
+
 .PHONY: all test install build clean
 
 all: ;
@@ -21,15 +26,12 @@ all: ;
 build: target/release/libatc_router.so target/release/libatc_router.a
 
 target/release/libatc_router.%: src/*.rs
-ifeq (, $(shell cargo))
-$(error "cargo not found in PATH, consider doing \"curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh\"")
-endif
-	cargo build --release
+	$(CARGO) build --release --target $(TARGET)
 
 install: build
 	$(INSTALL) -d $(DESTDIR)$(LUA_LIB_DIR)/resty/router/
 	$(INSTALL) -m 664 lib/resty/router/*.lua $(DESTDIR)$(LUA_LIB_DIR)/resty/router/
-	$(INSTALL) -m 775 target/release/libatc_router.$(SHLIB_EXT) $(DESTDIR)$(LUA_LIB_DIR)/libatc_router.so
+	$(INSTALL) -m 775 target/*/release/libatc_router.$(SHLIB_EXT) $(DESTDIR)$(LUA_LIB_DIR)/libatc_router.so
 
 clean:
 	rm -rf target


### PR DESCRIPTION
implement semmantic release automation such that commit messages that follow conventional commits ( [1](https://github.com/Kong/atc-router/blob/feat/releases/.releaserc#L9) )( [2](https://www.conventionalcommits.org/en/v1.0.0/) ) along with musl / gnu release artifacts for x86_64 and aarch64

![image](https://user-images.githubusercontent.com/697188/202245810-972f0341-ec0d-4391-a577-4f8bab4bba5b.png)

![image](https://user-images.githubusercontent.com/697188/202245908-985f8798-1f5e-4542-810e-f8ef4d99c198.png)
