### PR TITLE
fix(ffi): correctly handle invalid UTF-8 sequences from field value

### DIFF
--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -30,14 +30,14 @@ impl TryFrom<&CValue> for Value {
             CValue::CString(s) => Self::String(unsafe {
                 ffi::CStr::from_ptr(*s as *const c_char)
                     .to_str()
-                    .unwrap()
+                    .map_err(|e| e.to_string())?
                     .to_string()
             }),
             CValue::CIpCidr(s) => Self::IpCidr(
                 unsafe {
                     ffi::CStr::from_ptr(*s as *const c_char)
                         .to_str()
-                        .unwrap()
+                        .map_err(|e| e.to_string())?
                         .to_string()
                 }
                 .parse::<IpCidr>()
@@ -47,7 +47,7 @@ impl TryFrom<&CValue> for Value {
                 unsafe {
                     ffi::CStr::from_ptr(*s as *const c_char)
                         .to_str()
-                        .unwrap()
+                        .map_err(|e| e.to_string())?
                         .to_string()
                 }
                 .parse::<IpAddr>()

--- a/t/02-bugs.t
+++ b/t/02-bugs.t
@@ -1,0 +1,86 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(2);
+
+plan tests => repeat_each() * blocks() * 5;
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_package_cpath "$pwd/target/debug/?.so;;";
+};
+
+no_long_string();
+no_diff();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: invalid UTF-8 sequence returns the decoding error
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local schema = require("resty.router.schema")
+            local context = require("resty.router.context")
+
+            local s = schema.new()
+
+            s:add_field("http.path", "String")
+
+            local BAD_UTF8 = {
+                "\x80",
+                "\xbf",
+                "\xfc\x80\x80\x80\x80\xaf",
+            }
+
+            local c = context.new(s)
+            for _, v in ipairs(BAD_UTF8) do
+                local ok, err = c:add_value("http.path", v)
+                ngx.say(err)
+            end
+        }
+    }
+--- request
+GET /t
+--- response_body
+invalid utf-8 sequence of 1 bytes from index 0
+invalid utf-8 sequence of 1 bytes from index 0
+invalid utf-8 sequence of 1 bytes from index 0
+--- no_error_log
+[error]
+[warn]
+[crit]
+
+
+
+=== TEST 2: NULL bytes does not cause UTF-8 issues (it is valid UTF-8)
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local schema = require("resty.router.schema")
+            local context = require("resty.router.context")
+
+            local s = schema.new()
+
+            s:add_field("http.path", "String")
+
+            local c = context.new(s)
+            assert(c:add_value("http.path", "\x00"))
+            ngx.say("ok")
+        }
+    }
+--- request
+GET /t
+--- response_body
+ok
+--- no_error_log
+[error]
+[warn]
+[crit]


### PR DESCRIPTION
Before:

```
$ prove -r t/02-bugs.t 
t/02-bugs.t .. 1/10 
#   Failed test 'TEST 1: invalid UTF-8 sequence returns the decoding error - status code ok'
#   at /usr/local/share/perl5/Test/Nginx/Socket.pm line 935.
#          got: ''
#     expected: '200'

#   Failed test 'TEST 1: invalid UTF-8 sequence returns the decoding error - response_body - response is expected (repeated req 0, req 0)'
#   at /usr/local/share/perl5/Test/Nginx/Socket.pm line 1382.
#          got: ''
#     expected: 'true
# a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c
# /foo
# '
TEST 1: invalid UTF-8 sequence returns the decoding error - Can't connect to 127.0.0.1:1984: Connection refused
	Retry connecting after 0.675 sec
TEST 1: invalid UTF-8 sequence returns the decoding error - Can't connect to 127.0.0.1:1984: Connection refused
	Retry connecting after 0.825 sec
^C
```

After:

```
$ prove -r t/02-bugs.t 
t/02-bugs.t .. ok     
All tests successful.
Files=1, Tests=20,  0 wallclock secs ( 0.01 usr  0.00 sys +  0.15 cusr  0.04 csys =  0.20 CPU)
Result: PASS
```