### PR TITLE
feat(grammar) rawstring

### DIFF
--- a/src/atc_grammar.pest
+++ b/src/atc_grammar.pest
@@ -18,7 +18,7 @@ str_char = { !("\"" | "\\") ~ ANY }
 str_esc = { "\\" ~ ("\"" | "\\" | "n" | "r" | "t") }
 
 rawstr_literal = ${ "`" ~ rawstr_char* ~ "`" }
-rawstr_char = { !"`" ~ ANY}
+rawstr_char = { !"`" ~ ANY }
 
 ipv4_literal = @{ ASCII_DIGIT{1,3} ~ ( "." ~ ASCII_DIGIT{1,3} ){3} }
 ipv6_literal = @{

--- a/src/atc_grammar.pest
+++ b/src/atc_grammar.pest
@@ -17,7 +17,7 @@ str_inner = _{ (str_esc | str_char)* }
 str_char = { !("\"" | "\\") ~ ANY }
 str_esc = { "\\" ~ ("\"" | "\\" | "n" | "r" | "t") }
 
-rawstr_literal = ${"`" ~ rawstr_char* ~ "`"}
+rawstr_literal = ${ "`" ~ rawstr_char* ~ "`" }
 rawstr_char = { !"`" ~ ANY}
 
 ipv4_literal = @{ ASCII_DIGIT{1,3} ~ ( "." ~ ASCII_DIGIT{1,3} ){3} }

--- a/src/atc_grammar.pest
+++ b/src/atc_grammar.pest
@@ -17,8 +17,8 @@ str_inner = _{ (str_esc | str_char)* }
 str_char = { !("\"" | "\\") ~ ANY }
 str_esc = { "\\" ~ ("\"" | "\\" | "n" | "r" | "t") }
 
-rawstr_literal = ${ "`" ~ rawstr_char* ~ "`" }
-rawstr_char = { !"`" ~ ANY }
+rawstr_literal = ${ "r#\"" ~ rawstr_char* ~ "\"#" }
+rawstr_char = { !"\"#" ~ ANY }
 
 ipv4_literal = @{ ASCII_DIGIT{1,3} ~ ( "." ~ ASCII_DIGIT{1,3} ){3} }
 ipv6_literal = @{

--- a/src/atc_grammar.pest
+++ b/src/atc_grammar.pest
@@ -1,6 +1,6 @@
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
 ident = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_" | ".")* }
-rhs = { str_literal | ip_literal | int_literal }
+rhs = { str_literal | rawstr_literal | ip_literal | int_literal }
 transform_func = { ident ~ "(" ~ lhs ~ ")" }
 lhs = { transform_func | ident }
 
@@ -17,6 +17,8 @@ str_inner = _{ (str_esc | str_char)* }
 str_char = { !("\"" | "\\") ~ ANY }
 str_esc = { "\\" ~ ("\"" | "\\" | "n" | "r" | "t") }
 
+rawstr_literal = ${"`" ~ rawstr_char* ~ "`"}
+rawstr_char = { !"`" ~ ANY}
 
 ipv4_literal = @{ ASCII_DIGIT{1,3} ~ ( "." ~ ASCII_DIGIT{1,3} ){3} }
 ipv6_literal = @{

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -88,6 +88,18 @@ impl ATCParser {
 
         Ok(s)
     }
+    fn rawstr_literal(input: Node) -> ParseResult<String> {
+        let mut s = String::new();
+       
+        for node in input.into_children() {
+            match node.as_rule() {
+                Rule::rawstr_char => s.push_str(node.as_str()),
+                _ => unreachable!(),
+            }
+        }
+
+        Ok(s)
+    }
 
     fn ipv4_cidr_literal(input: Node) -> ParseResult<Ipv4Cidr> {
         input.as_str().parse().into_parse_result(&input)
@@ -142,6 +154,7 @@ impl ATCParser {
     fn rhs(input: Node) -> ParseResult<Value> {
         Ok(match_nodes! { input.children();
             [str_literal(s)] => Value::String(s),
+            [rawstr_literal(s)] => Value::String(s),
             [ip_literal(ip)] => Value::IpCidr(ip),
             [int_literal(i)] => Value::Int(i),
         })

--- a/t/04-rawstr.t
+++ b/t/04-rawstr.t
@@ -37,7 +37,7 @@ __DATA__
 
             local r = router.new(s)
             assert(r:add_matcher(0, "a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c",
-                                 "http.path ^= `/foo` && tcp.port == 80"))
+                                 "http.path ^= r#\"/foo\"# && tcp.port == 80"))
 
             local c = context.new(s)
             c:add_value("http.path", "/foo/bar")
@@ -80,7 +80,7 @@ a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c
 
             local r = router.new(s)
             assert(r:add_matcher(0, "a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c",
-                                 "http.path ^= `/foo\"\'` && tcp.port == 80"))
+                                 "http.path ^= r#\"/foo\"\'\"# && tcp.port == 80"))
 
             local c = context.new(s)
             c:add_value("http.path", "/foo\"\'/bar")
@@ -124,7 +124,7 @@ a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c
 
             local r = router.new(s)
             assert(r:add_matcher(0, "a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c",
-                                 "http.path ~ `^/\\d+/test$` && tcp.port == 80"))
+                                 "http.path ~ r#\"^/\\d+/test$\"# && tcp.port == 80"))
 
             local c = context.new(s)
             c:add_value("http.path", "/123/test")
@@ -167,7 +167,7 @@ a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c
 
             local r = router.new(s)
             assert(r:add_matcher(0, "a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c",
-                                 "http.path ~ `^/\\D+/test$` && tcp.port == 80"))
+                                 "http.path ~ r#\"^/\\D+/test$\"# && tcp.port == 80"))
 
             local c = context.new(s)
             c:add_value("http.path", "/123/test")

--- a/t/04-rawstr.t
+++ b/t/04-rawstr.t
@@ -63,3 +63,133 @@ a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c
 [crit]
 
 
+
+=== TEST 2: rawstr with quote inside
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local schema = require("resty.router.schema")
+            local router = require("resty.router.router")
+            local context = require("resty.router.context")
+
+            local s = schema.new()
+
+            s:add_field("http.path", "String")
+            s:add_field("tcp.port", "Int")
+
+            local r = router.new(s)
+            assert(r:add_matcher(0, "a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c",
+                                 "http.path ^= `/foo\"\'` && tcp.port == 80"))
+
+            local c = context.new(s)
+            c:add_value("http.path", "/foo\"\'/bar")
+            c:add_value("tcp.port", 80)
+
+            local matched = r:execute(c)
+            ngx.say(matched)
+
+            local uuid, prefix = c:get_result("http.path")
+            ngx.say(uuid)
+            ngx.say(prefix)
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c
+/foo"'
+--- no_error_log
+[error]
+[warn]
+[crit]
+
+
+
+
+=== TEST 3: rawstr with regex inside
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local schema = require("resty.router.schema")
+            local router = require("resty.router.router")
+            local context = require("resty.router.context")
+
+            local s = schema.new()
+
+            s:add_field("http.path", "String")
+            s:add_field("tcp.port", "Int")
+
+            local r = router.new(s)
+            assert(r:add_matcher(0, "a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c",
+                                 "http.path ~ `^/\\d+/test$` && tcp.port == 80"))
+
+            local c = context.new(s)
+            c:add_value("http.path", "/123/test")
+            c:add_value("tcp.port", 80)
+
+            local matched = r:execute(c)
+            ngx.say(matched)
+
+            local uuid, prefix = c:get_result("http.path")
+            ngx.say(uuid)
+            ngx.say(prefix)
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c
+/123/test
+--- no_error_log
+[error]
+[warn]
+[crit]
+
+
+
+=== TEST 4: rawstr with regex inside expect mismatch
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local schema = require("resty.router.schema")
+            local router = require("resty.router.router")
+            local context = require("resty.router.context")
+
+            local s = schema.new()
+
+            s:add_field("http.path", "String")
+            s:add_field("tcp.port", "Int")
+
+            local r = router.new(s)
+            assert(r:add_matcher(0, "a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c",
+                                 "http.path ~ `^/\\D+/test$` && tcp.port == 80"))
+
+            local c = context.new(s)
+            c:add_value("http.path", "/123/test")
+            c:add_value("tcp.port", 80)
+
+            local matched = r:execute(c)
+            ngx.say(matched)
+
+            local uuid, prefix = c:get_result("http.path")
+            ngx.say(uuid)
+            ngx.say(prefix)
+        }
+    }
+--- request
+GET /t
+--- response_body
+false
+nil
+nil
+--- no_error_log
+[error]
+[warn]
+[crit]
+
+

--- a/t/04-rawstr.t
+++ b/t/04-rawstr.t
@@ -1,0 +1,65 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(2);
+
+plan tests => repeat_each() * blocks() * 5;
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_package_cpath "$pwd/target/debug/?.so;;";
+};
+
+no_long_string();
+no_diff();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: rawstr
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local schema = require("resty.router.schema")
+            local router = require("resty.router.router")
+            local context = require("resty.router.context")
+
+            local s = schema.new()
+
+            s:add_field("http.path", "String")
+            s:add_field("tcp.port", "Int")
+
+            local r = router.new(s)
+            assert(r:add_matcher(0, "a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c",
+                                 "http.path ^= `/foo` && tcp.port == 80"))
+
+            local c = context.new(s)
+            c:add_value("http.path", "/foo/bar")
+            c:add_value("tcp.port", 80)
+
+            local matched = r:execute(c)
+            ngx.say(matched)
+
+            local uuid, prefix = c:get_result("http.path")
+            ngx.say(uuid)
+            ngx.say(prefix)
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c
+/foo
+--- no_error_log
+[error]
+[warn]
+[crit]
+
+


### PR DESCRIPTION
Now we can use \` to construct string so that we don't need to repeatedly write escape slashes.

_Fix KAG-370_