### PR TITLE
chore(build): remove cargo binary check from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,9 +21,6 @@ all: ;
 build: target/release/libatc_router.so target/release/libatc_router.a
 
 target/release/libatc_router.%: src/*.rs
-ifeq (, $(shell cargo))
-$(error "cargo not found in PATH, consider doing \"curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh\"")
-endif
 	cargo build --release
 
 install: build


### PR DESCRIPTION
This check has proven to be somewhat error-prone, and it's a little bit handhold-y for a Makefile. If cargo is truly not installed, this error seems plenty explanatory for an average developer:

```
$ make build
cargo build --release
make: cargo: No such file or directory
make: *** [Makefile:27: target/release/libatc_router.so] Error 127
```

