### PR TITLE
feat(ci): add lint and sca workflows using shared actions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -2,6 +2,7 @@ name: Lint
 
 on:
   pull_request: {}
+  workflow_dispatch: {}
   push:
     branches:
       - main
@@ -11,24 +12,57 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  tests:
-    name: Lint
+  lua-lint:
+    name: Lua Lint
     runs-on: ubuntu-20.04
+    permissions:
+      contents: read
+      issues: read
+      checks: write
+      pull-requests: write
+    if: (github.actor != 'dependabot[bot]')
 
     steps:
     - name: Checkout source code
       uses: actions/checkout@v3
-    - uses: Jayrgo/luacheck-action@v1
-      name: luacheck
+    
+    # Optional step to run on only changed files
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v36
+      with: 
+        files: |
+          **.lua
+    
+    - name: Lua Check
+      if: steps.changed-files.outputs.any_changed == 'true'
+      uses: Kong/public-shared-actions/code-check-actions/lua-lint@v1
       with:
-        # List of files, directories and rockspecs to check.
-        # Default: .
-        files: 'lib'
+        additional_args: '--no-default-config --config .luacheckrc'
+        files: ${{ steps.changed-files.outputs.all_changed_files }}
+  
+  rust-lint:
+    name: Rust Clippy
+    runs-on: ubuntu-20.04
+    
+    permissions:
+      # required for all workflows
+      security-events: write
+      checks: write
+      pull-requests: write
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+  
+    if: (github.actor != 'dependabot[bot]')
+    
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v3
 
-        # Path to configuration file.
-        # Default: .luacheckrc
-        config: '.luacheckrc'
-
-        # Arguments passed to luacheck.
-        # Default: -q
-        args: '-q'
+    - name: Rust Clippy
+      uses: Kong/public-shared-actions/code-check-actions/rust-lint@v1
+      with:
+        asset_prefix: 'atc-router'
+        token: ${{ secrets.GITHUB_TOKEN }}
+        

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -59,8 +59,17 @@ jobs:
     steps:
     - name: Checkout source code
       uses: actions/checkout@v3
+    
+    # Optional step to run on only changed files
+    - name: Get changed files
+      id: changed-files
+      uses: tj-actions/changed-files@v36
+      with: 
+        files: |
+          **.rs
 
     - name: Rust Clippy
+      if: steps.changed-files.outputs.any_changed == 'true'
       uses: Kong/public-shared-actions/code-check-actions/rust-lint@v1
       with:
         asset_prefix: 'atc-router'

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -12,8 +12,8 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
-  lua-lint:
-    name: Lua Lint
+  lua-check:
+    name: Lua Check
     runs-on: ubuntu-20.04
     permissions:
       contents: read
@@ -41,7 +41,7 @@ jobs:
         additional_args: '--no-default-config --config .luacheckrc'
         files: ${{ steps.changed-files.outputs.all_changed_files }}
   
-  rust-lint:
+  rust-clippy:
     name: Rust Clippy
     runs-on: ubuntu-20.04
     
@@ -72,6 +72,5 @@ jobs:
       if: steps.changed-files.outputs.any_changed == 'true'
       uses: Kong/public-shared-actions/code-check-actions/rust-lint@v1
       with:
-        asset_prefix: 'atc-router'
         token: ${{ secrets.GITHUB_TOKEN }}
         

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -1,0 +1,30 @@
+name: SAST
+
+on:
+  pull_request: {}
+  push:
+    branches: 
+    - master
+    - main
+  workflow_dispatch: {}
+
+
+jobs:
+  semgrep:
+    name: Semgrep SAST
+    runs-on: ubuntu-20.04
+    permissions:
+      # required for all workflows
+      security-events: write
+      # only required for workflows in private repositories
+      actions: read
+      contents: read
+
+    if: (github.actor != 'dependabot[bot]')
+
+    steps:
+      - uses: actions/checkout@v3
+      - uses: Kong/public-shared-actions/security-actions/semgrep@v1
+        with:
+          additional_config: '--config p/rust'
+            

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -1,4 +1,4 @@
-name: Source code analysis
+name: SCA
 
 on:
   pull_request: {}
@@ -31,9 +31,7 @@ jobs:
     - name: Checkout source code
       uses: actions/checkout@v3
 
-    - name: Rust Check
+    - name: Rust SCA
       uses: Kong/public-shared-actions/security-actions/scan-rust@v1
       with:
         asset_prefix: 'atc-router'
-        token: ${{ secrets.GITHUB_TOKEN }}
-        

--- a/.github/workflows/sca.yml
+++ b/.github/workflows/sca.yml
@@ -1,0 +1,39 @@
+name: Source code analysis
+
+on:
+  pull_request: {}
+  workflow_dispatch: {}
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+
+  rust-sca:
+    name: Rust SCA
+    runs-on: ubuntu-20.04
+    
+    permissions:
+      # required for all workflows
+      security-events: write
+      checks: write
+      pull-requests: write
+      actions: read
+      contents: read
+  
+    if: (github.actor != 'dependabot[bot]')
+    
+    steps:
+    - name: Checkout source code
+      uses: actions/checkout@v3
+
+    - name: Rust Check
+      uses: Kong/public-shared-actions/security-actions/scan-rust@v1
+      with:
+        asset_prefix: 'atc-router'
+        token: ${{ secrets.GITHUB_TOKEN }}
+        


### PR DESCRIPTION
Can I get a review on the shared action integration for Luacheck/ rust-clippy and rust sca using grype ?

## How to test and provide feedback?
 - When the PR is merged, linters (lua / rust) runs on other `PR` and `main` branches and create checks and status reports based on changed and dirty files between commits
 - Semgrep and rust CVE analysis is reported to GitHub code scanning for public repositories.

## Shared actions used:
  - https://github.com/Kong/public-shared-actions/tree/main/code-check-actions/rust-lint
  - https://github.com/Kong/public-shared-actions/tree/main/code-check-actions/lua-lint
  - https://github.com/Kong/public-shared-actions/tree/main/security-actions/semgrep
  - https://github.com/Kong/public-shared-actions/tree/main/security-actions/scan-rust