### PR TITLE
feat(serde): add serde integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,8 @@ dependencies = [
  "pest",
  "pest_derive",
  "regex",
+ "serde",
+ "serde_regex",
  "uuid",
 ]
 
@@ -43,6 +45,9 @@ name = "cidr"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d18b093eba54c9aaa1e3784d4361eb2ba944cf7d0a932a830132238f483e8d8"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "cpufeatures"
@@ -198,6 +203,36 @@ name = "regex-syntax"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
+
+[[package]]
+name = "serde"
+version = "1.0.179"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a5bf42b8d227d4abf38a1ddb08602e229108a517cd4e5bb28f9c7eaafdce5c0"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.179"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "741e124f5485c7e60c03b043f79f320bff3527f4bbf12cf3831750dc46a0ec2c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_regex"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8136f1a4ea815d7eac4101cfd0b16dc0cb5e1fe1b8609dfd728058656b7badf"
+dependencies = [
+ "regex",
+ "serde",
+]
 
 [[package]]
 name = "sha2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ lazy_static = "1.4"
 uuid = "1.5"
 regex = "1.10"
 serde = { version = "1.0", features = ["derive"], optional = true }
-serde_regex = { version = "1.1.0", optional = true }
+serde_regex = { version = "1.1", optional = true }
 
 [lib]
 crate-type = ["lib", "cdylib", "staticlib"]
@@ -25,4 +25,4 @@ crate-type = ["lib", "cdylib", "staticlib"]
 [features]
 default = ["ffi"]
 ffi = []
-serde = ["cidr/serde", "dep:serde", "serde_regex"]
+serde = ["cidr/serde", "dep:serde", "dep:serde_regex"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,6 @@ serde_regex = { version = "1.1.0", optional = true }
 crate-type = ["lib", "cdylib", "staticlib"]
 
 [features]
-no-ffi = []
+default = ["ffi"]
+ffi = []
 serde = ["cidr/serde", "dep:serde", "serde_regex"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,12 @@ cidr = "0.2"
 lazy_static = "1.4"
 uuid = "1.5"
 regex = "1.10"
+serde = { version = "1.0", features = ["derive"], optional = true }
+serde_regex = { version = "1.1.0", optional = true }
 
 [lib]
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["lib", "cdylib", "staticlib"]
+
+[features]
+no-ffi = []
+serde = ["cidr/serde", "dep:serde", "serde_regex"]

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -3,24 +3,31 @@ use cidr::IpCidr;
 use regex::Regex;
 use std::net::IpAddr;
 
+#[cfg(feature = "serde")]
+use serde::{Deserialize, Serialize};
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub enum Expression {
     Logical(Box<LogicalExpression>),
     Predicate(Predicate),
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub enum LogicalExpression {
     And(Expression, Expression),
     Or(Expression, Expression),
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq)]
 pub enum LhsTransformations {
     Lower,
     Any,
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, PartialEq, Eq)]
 pub enum BinaryOperator {
     Equals,         // ==
@@ -37,12 +44,14 @@ pub enum BinaryOperator {
     Contains,       // contains
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Clone)]
 pub enum Value {
     String(String),
     IpCidr(IpCidr),
     IpAddr(IpAddr),
     Int(i64),
+    #[cfg_attr(feature = "serde", serde(with = "serde_regex"))]
     Regex(Regex),
 }
 
@@ -73,6 +82,7 @@ impl Value {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Eq, PartialEq)]
 #[repr(C)]
 pub enum Type {
@@ -83,6 +93,7 @@ pub enum Type {
     Regex,
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Lhs {
     pub var_name: String,
@@ -107,6 +118,7 @@ impl Lhs {
     }
 }
 
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug)]
 pub struct Predicate {
     pub lhs: Lhs,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -7,7 +7,7 @@ pub mod schema;
 pub mod semantics;
 mod ast_tests;
 
-#[cfg(not(feature = "no-ffi"))]
+#[cfg(feature = "ffi")]
 pub mod ffi;
 
 #[macro_use]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,14 @@
-mod ast;
-mod context;
-pub mod ffi;
-mod interpreter;
-mod parser;
-mod router;
-mod schema;
-mod semantics;
+pub mod ast;
+pub mod context;
+pub mod interpreter;
+pub mod parser;
+pub mod router;
+pub mod schema;
+pub mod semantics;
 mod ast_tests;
+
+#[cfg(not(feature = "no-ffi"))]
+pub mod ffi;
 
 #[macro_use]
 extern crate pest_derive;


### PR DESCRIPTION
This pull request is a prerequisite for the external crate containing ATC Router's WASM binding

- Adding `lib` to `crate-type` to allow this crate to be used by other crates
- Adding a `serde` feature to apply `serde` macros selectively
- Adding a `no-ffi` feature to exclude `ffi` from mods to avoid symbol conflicts while being used as a dependency

KAG-2426