### PR TITLE
chore(build): ensure `ffi` feature is enabled when producing builds with Bazel

### DIFF
--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -30,3 +30,11 @@ jobs:
 
     - name: Build
       run: bazel build :atc_router --verbose_failures
+
+    - name: Ensure `ffi` feature is present (Linux)
+      if: ${{ matrix.os == "ubuntu-latest" }}
+      run: readelf -Ws --dyn-syms bazel-bin/libatc_router.so | grep router_execute
+
+    - name: Ensure `ffi` feature is present (macOS)
+      if: ${{ matrix.os == "macos-latest" }}
+      run: readelf -Ws --dyn-syms bazel-bin/libatc_router.so | grep router_execute

--- a/.github/workflows/bazel.yml
+++ b/.github/workflows/bazel.yml
@@ -32,9 +32,9 @@ jobs:
       run: bazel build :atc_router --verbose_failures
 
     - name: Ensure `ffi` feature is present (Linux)
-      if: ${{ matrix.os == "ubuntu-latest" }}
+      if: ${{ matrix.os == 'ubuntu-latest' }}
       run: readelf -Ws --dyn-syms bazel-bin/libatc_router.so | grep router_execute
 
     - name: Ensure `ffi` feature is present (macOS)
-      if: ${{ matrix.os == "macos-latest" }}
-      run: readelf -Ws --dyn-syms bazel-bin/libatc_router.so | grep router_execute
+      if: ${{ matrix.os == 'macos-latest' }}
+      run: nm -gU bazel-bin/libatc_router.dylib | grep router_execute

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -12,6 +12,7 @@ filegroup(
 rust_shared_library(
     name = "atc_router",
     srcs = [":all_srcs"],
+    crate_features = ["default", "ffi"],
     aliases = aliases(),
     proc_macro_deps = all_crate_deps(
         proc_macro = True,


### PR DESCRIPTION
Added a test to ensure FFI module is being built. Resolves error like: https://github.com/Kong/kong/actions/runs/6718688600/job/18259139028.