### PR TITLE
perf(interpreter): improve performance of regex matching and field reference

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -16,6 +16,7 @@ name = "atc-router"
 version = "1.3.1"
 dependencies = [
  "cidr",
+ "fnv",
  "lazy_static",
  "pest",
  "pest_derive",
@@ -79,6 +80,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fnv"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -96,9 +103,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.149"
+version = "0.2.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a08173bc88b7955d1b3145aa561539096c421ac8debde8cbc3612ec635fee29b"
+checksum = "302d7ab3130588088d277783b1e2d2e10c9e9e4a16dd9050e6ec93fb3e7048f4"
 
 [[package]]
 name = "memchr"
@@ -108,9 +115,9 @@ checksum = "f665ee40bc4a3c5590afb1e9677db74a508659dfd71e126420da8274909a0167"
 
 [[package]]
 name = "once_cell"
-version = "1.18.0"
+version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd8b5dd2ae5ed71462c540258bedcb51965123ad7e7ccf4b9a8cafaa4a63576d"
+checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
 
 [[package]]
 name = "pest"
@@ -159,9 +166,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.69"
+version = "1.0.70"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "134c189feb4956b20f6f547d2cf727d4c0fe06722b20a0eec87ed445a97f92da"
+checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
 dependencies = [
  "unicode-ident",
 ]
@@ -247,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.38"
+version = "2.0.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e96b79aaa137db8f61e26363a0c9b47d8b4ec75da28b7d1d614c2303e232408b"
+checksum = "13fa70a4ee923979ffb522cacce59d34421ebdea5625e1073c4326ef9d2dd42e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -254,9 +254,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.40"
+version = "2.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13fa70a4ee923979ffb522cacce59d34421ebdea5625e1073c4326ef9d2dd42e"
+checksum = "44c8b28c477cc3bf0e7966561e3460130e1255f7a1cf71931075f1c5e7a7e269"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -265,18 +265,18 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9a7210f5c9a7156bb50aa36aed4c95afb51df0df00713949448cf9e97d382d2"
+checksum = "f11c217e1416d6f036b870f14e0413d480dbf28edbee1f877abaf0206af43bb7"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.50"
+version = "1.0.51"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "266b2e40bc00e5a6c09c3584011e08b06f123c00362c92b975ba9843aaaa14b8"
+checksum = "01742297787513b79cf8e29d1056ede1313e2420b7b3b15d0a768b4921f549df"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,7 @@ pest_derive = "2.7"
 cidr = "0.2"
 lazy_static = "1.4"
 uuid = "1.6"
-regex = "1.10"
+regex = "1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_regex = { version = "1.1", optional = true }
 fnv = "1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ uuid = "1.6"
 regex = "1.10"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_regex = { version = "1.1", optional = true }
+fnv = "1"
 
 [lib]
 crate-type = ["lib", "cdylib", "staticlib"]

--- a/README.md
+++ b/README.md
@@ -2,8 +2,7 @@
 
 ATC Router library for Kong.
 
-Table of Contents
-=================
+# Table of Contents
 
 * [Name](#name)
 * [Semantics](#semantics)
@@ -23,6 +22,7 @@ Table of Contents
         * [new](#new)
         * [add\_value](#add_value)
         * [get\_result](#get_result)
+        * [reset](#reset)
 * [Copyright and license](#copyright-and-license)
 
 # Semantics
@@ -205,6 +205,17 @@ If the context did not contain a valid match result, `nil` is returned.
 
 Otherwise, the string UUID, value matching field `matched_field` and
 regex captures from the matched route are returned.
+
+[Back to TOC](#table-of-contents)
+
+### reset
+
+**syntax:** *c:reset()*
+
+**context:** *any*
+
+This resets context `c` without deallocating the underlying memory
+so the context can be used again as if it was just created.
 
 [Back to TOC](#table-of-contents)
 

--- a/lib/resty/router/cdefs.lua
+++ b/lib/resty/router/cdefs.lua
@@ -77,6 +77,8 @@ bool context_add_value(struct Context *context,
                        uint8_t *errbuf,
                        uintptr_t *errbuf_len);
 
+void context_reset(struct Context *context);
+
 intptr_t context_get_result(const struct Context *context,
                             uint8_t *uuid_hex,
                             const int8_t *matched_field,

--- a/lib/resty/router/context.lua
+++ b/lib/resty/router/context.lua
@@ -131,4 +131,8 @@ function _M:get_result(matched_field)
 end
 
 
+function _M:reset()
+    clib.context_reset(self.context)
+end
+
 return _M

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -82,6 +82,12 @@ impl Value {
     }
 }
 
+impl From<String> for Value {
+    fn from(v: String) -> Self {
+        Value::String(v)
+    }
+}
+
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Debug, Eq, PartialEq)]
 #[repr(C)]

--- a/src/context.rs
+++ b/src/context.rs
@@ -35,7 +35,7 @@ impl<'a> Context<'a> {
     pub fn new(schema: &'a Schema) -> Self {
         Context {
             schema,
-            values: FnvHashMap::default(),
+            values: FnvHashMap::with_capacity_and_hasher(8, Default::default()),
             result: None,
         }
     }
@@ -53,5 +53,9 @@ impl<'a> Context<'a> {
 
     pub fn value_of(&self, field: &str) -> Option<&[Value]> {
         self.values.get(field).map(|v| v.as_slice())
+    }
+
+    pub fn reset(&mut self) {
+        self.values.clear();
     }
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -1,20 +1,20 @@
 use crate::ast::Value;
 use crate::schema::Schema;
-use std::collections::HashMap;
+use fnv::FnvHashMap;
 use uuid::Uuid;
 
 pub struct Match {
     pub uuid: Uuid,
-    pub matches: HashMap<String, Value>,
-    pub captures: HashMap<String, String>,
+    pub matches: FnvHashMap<String, Value>,
+    pub captures: FnvHashMap<String, String>,
 }
 
 impl Match {
     pub fn new() -> Self {
         Match {
             uuid: Uuid::default(),
-            matches: HashMap::new(),
-            captures: HashMap::new(),
+            matches: FnvHashMap::default(),
+            captures: FnvHashMap::default(),
         }
     }
 }
@@ -27,7 +27,7 @@ impl Default for Match {
 
 pub struct Context<'a> {
     schema: &'a Schema,
-    values: HashMap<String, Vec<Value>>,
+    values: FnvHashMap<String, Vec<Value>>,
     pub result: Option<Match>,
 }
 
@@ -35,7 +35,7 @@ impl<'a> Context<'a> {
     pub fn new(schema: &'a Schema) -> Self {
         Context {
             schema,
-            values: HashMap::new(),
+            values: FnvHashMap::default(),
             result: None,
         }
     }

--- a/src/context.rs
+++ b/src/context.rs
@@ -35,7 +35,7 @@ impl<'a> Context<'a> {
     pub fn new(schema: &'a Schema) -> Self {
         Context {
             schema,
-            values: FnvHashMap::with_capacity_and_hasher(8, Default::default()),
+            values: FnvHashMap::with_hasher(Default::default()),
             result: None,
         }
     }

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -191,6 +191,11 @@ pub unsafe extern "C" fn context_add_value(
 }
 
 #[no_mangle]
+pub unsafe extern "C" fn context_reset(context: &mut Context) {
+    context.reset();
+}
+
+#[no_mangle]
 pub unsafe extern "C" fn context_get_result(
     context: &Context,
     uuid_hex: *mut u8,

--- a/src/ffi.rs
+++ b/src/ffi.rs
@@ -61,7 +61,7 @@ impl TryFrom<&CValue> for Value {
 
 #[no_mangle]
 pub extern "C" fn schema_new() -> *mut Schema {
-    Box::into_raw(Box::new(Schema::default()))
+    Box::into_raw(Box::default())
 }
 
 #[no_mangle]

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -75,9 +75,9 @@ impl Execute for Predicate {
                         _ => unreachable!(),
                     };
 
-                    let reg_cap = rhs.captures(lhs);
+                    if rhs.is_match(lhs) {
+                        let reg_cap = rhs.captures(lhs).unwrap();
 
-                    if let Some(reg_cap) = reg_cap {
                         m.matches.insert(
                             self.lhs.var_name.clone(),
                             Value::String(reg_cap.get(0).unwrap().as_str().to_string()),

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -46,10 +46,8 @@ impl Execute for Predicate {
             match self.op {
                 BinaryOperator::Equals => {
                     if lhs_value == &self.rhs {
-                        if self.lhs.var_name == "http.path" {
-                            m.matches
-                                .insert(self.lhs.var_name.clone(), self.rhs.clone());
-                        }
+                        m.matches
+                            .insert(self.lhs.var_name.clone(), self.rhs.clone());
 
                         if any {
                             return true;
@@ -80,12 +78,10 @@ impl Execute for Predicate {
                     if rhs.is_match(lhs) {
                         let reg_cap = rhs.captures(lhs).unwrap();
 
-                        if self.lhs.var_name == "http.path" {
-                            m.matches.insert(
-                                self.lhs.var_name.clone(),
-                                Value::String(reg_cap.get(0).unwrap().as_str().to_string()),
-                            );
-                        }
+                        m.matches.insert(
+                            self.lhs.var_name.clone(),
+                            Value::String(reg_cap.get(0).unwrap().as_str().to_string()),
+                        );
 
                         for (i, c) in reg_cap.iter().enumerate() {
                             if let Some(c) = c {
@@ -118,10 +114,8 @@ impl Execute for Predicate {
                     };
 
                     if lhs.starts_with(rhs) {
-                        if self.lhs.var_name == "http.path" {
-                            m.matches
-                                .insert(self.lhs.var_name.clone(), self.rhs.clone());
-                        }
+                        m.matches
+                            .insert(self.lhs.var_name.clone(), self.rhs.clone());
                         if any {
                             return true;
                         }
@@ -140,10 +134,8 @@ impl Execute for Predicate {
                     };
 
                     if lhs.ends_with(rhs) {
-                        if self.lhs.var_name == "http.path" {
-                            m.matches
-                                .insert(self.lhs.var_name.clone(), self.rhs.clone());
-                        }
+                        m.matches
+                            .insert(self.lhs.var_name.clone(), self.rhs.clone());
                         if any {
                             return true;
                         }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -46,8 +46,10 @@ impl Execute for Predicate {
             match self.op {
                 BinaryOperator::Equals => {
                     if lhs_value == &self.rhs {
-                        m.matches
-                            .insert(self.lhs.var_name.clone(), self.rhs.clone());
+                        if self.lhs.var_name == "http.path" {
+                            m.matches
+                                .insert(self.lhs.var_name.clone(), self.rhs.clone());
+                        }
 
                         if any {
                             return true;
@@ -78,10 +80,12 @@ impl Execute for Predicate {
                     if rhs.is_match(lhs) {
                         let reg_cap = rhs.captures(lhs).unwrap();
 
-                        m.matches.insert(
-                            self.lhs.var_name.clone(),
-                            Value::String(reg_cap.get(0).unwrap().as_str().to_string()),
-                        );
+                        if self.lhs.var_name == "http.path" {
+                            m.matches.insert(
+                                self.lhs.var_name.clone(),
+                                Value::String(reg_cap.get(0).unwrap().as_str().to_string()),
+                            );
+                        }
 
                         for (i, c) in reg_cap.iter().enumerate() {
                             if let Some(c) = c {
@@ -114,8 +118,10 @@ impl Execute for Predicate {
                     };
 
                     if lhs.starts_with(rhs) {
-                        m.matches
-                            .insert(self.lhs.var_name.clone(), self.rhs.clone());
+                        if self.lhs.var_name == "http.path" {
+                            m.matches
+                                .insert(self.lhs.var_name.clone(), self.rhs.clone());
+                        }
                         if any {
                             return true;
                         }
@@ -134,8 +140,10 @@ impl Execute for Predicate {
                     };
 
                     if lhs.ends_with(rhs) {
-                        m.matches
-                            .insert(self.lhs.var_name.clone(), self.rhs.clone());
+                        if self.lhs.var_name == "http.path" {
+                            m.matches
+                                .insert(self.lhs.var_name.clone(), self.rhs.clone());
+                        }
                         if any {
                             return true;
                         }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,7 +10,7 @@ use pest::iterators::Pair;
 use pest::pratt_parser::Assoc as AssocNew;
 use pest::pratt_parser::{Op, PrattParser};
 use pest::Parser;
-use regex::Regex;
+use regex::RegexBuilder;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 type ParseResult<T> = Result<T, ParseError<Rule>>;
@@ -195,14 +195,17 @@ fn parse_predicate(pair: Pair<Rule>) -> ParseResult<Predicate> {
         lhs,
         rhs: if op == BinaryOperator::Regex {
             if let Value::String(s) = rhs {
-                let r = Regex::new(&s).map_err(|e| {
-                    ParseError::new_from_span(
-                        ErrorVariant::CustomError {
-                            message: e.to_string(),
-                        },
-                        rhs_pair.as_span(),
-                    )
-                })?;
+                let r = RegexBuilder::new(&s)
+                    .dfa_size_limit(usize::MAX)
+                    .build()
+                    .map_err(|e| {
+                        ParseError::new_from_span(
+                            ErrorVariant::CustomError {
+                                message: e.to_string(),
+                            },
+                            rhs_pair.as_span(),
+                        )
+                    })?;
 
                 Value::Regex(r)
             } else {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -10,7 +10,7 @@ use pest::iterators::Pair;
 use pest::pratt_parser::Assoc as AssocNew;
 use pest::pratt_parser::{Op, PrattParser};
 use pest::Parser;
-use regex::RegexBuilder;
+use regex::Regex;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 type ParseResult<T> = Result<T, ParseError<Rule>>;
@@ -195,17 +195,14 @@ fn parse_predicate(pair: Pair<Rule>) -> ParseResult<Predicate> {
         lhs,
         rhs: if op == BinaryOperator::Regex {
             if let Value::String(s) = rhs {
-                let r = RegexBuilder::new(&s)
-                    .dfa_size_limit(usize::MAX)
-                    .build()
-                    .map_err(|e| {
-                        ParseError::new_from_span(
-                            ErrorVariant::CustomError {
-                                message: e.to_string(),
-                            },
-                            rhs_pair.as_span(),
-                        )
-                    })?;
+                let r = Regex::new(&s).map_err(|e| {
+                    ParseError::new_from_span(
+                        ErrorVariant::CustomError {
+                            message: e.to_string(),
+                        },
+                        rhs_pair.as_span(),
+                    )
+                })?;
 
                 Value::Regex(r)
             } else {


### PR DESCRIPTION
Rust regex crate can not use faster lazy DFA based matching when we ask
for captures. As a router, the chance of regex mismatch is higher,
therefore, it makes sense to use `is_match()` to check if regex match
first with the faster implementation before asking for capture using the
slower implementations (onepass DFA, Pike VM (NFA)).

HashMap by default uses SipHash which is DDoS resilient, in case hash
key collision is not a risk (e.g. field names), it makes sense to use a
HashDos non-resilient hashing function (e.g. Fowler–Noll–Vo hash) which
runs two orders of magnitude faster.

These improvements showed up to 50% performance improvement in regex
heavy synthetic scenarios, or about 20% improvement in field access heavy
synthetic scenarios.

[KAG-3403](https://konghq.atlassian.net/browse/KAG-3403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ)

[KAG-3403]: https://konghq.atlassian.net/browse/KAG-3403?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ