### PR TITLE
fix(context): clear matches on reset

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -57,5 +57,6 @@ impl<'a> Context<'a> {
 
     pub fn reset(&mut self) {
         self.values.clear();
+        self.result = None;
     }
 }

--- a/t/01-sanity.t
+++ b/t/01-sanity.t
@@ -193,3 +193,58 @@ nil --> 1:11
 [error]
 [warn]
 [crit]
+
+
+
+=== TEST 5: context:reset()
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local schema = require("resty.router.schema")
+            local router = require("resty.router.router")
+            local context = require("resty.router.context")
+
+            local s = schema.new()
+
+            s:add_field("http.path", "String")
+            s:add_field("tcp.port", "Int")
+
+            local r = router.new(s)
+            assert(r:add_matcher(0, "a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c",
+                                 "http.path ^= \"/foo\" && tcp.port == 80"))
+
+            local c = context.new(s)
+            c:add_value("http.path", "/foo/bar")
+            c:add_value("tcp.port", 80)
+
+            local matched = r:execute(c)
+            ngx.say(matched)
+
+            local uuid, prefix = c:get_result("http.path")
+            ngx.say(uuid)
+            ngx.say(prefix)
+
+            c:reset()
+
+            local uuid, prefix = c:get_result("http.path")
+            ngx.say(uuid)
+            ngx.say(prefix)
+
+            local matched = r:execute(c)
+            ngx.say(matched)
+        }
+    }
+--- request
+GET /t
+--- response_body
+true
+a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c
+/foo
+nil
+nil
+false
+--- no_error_log
+[error]
+[warn]
+[crit]


### PR DESCRIPTION
`self.result` should also be cleared on match. This makes sure the context does not think it has a match result.