### PR TITLE
feat(lib): add "not" logical operator support

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -18,6 +18,7 @@ pub enum Expression {
 pub enum LogicalExpression {
     And(Expression, Expression),
     Or(Expression, Expression),
+    Not(Expression),
 }
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
@@ -163,6 +164,9 @@ mod tests {
                     LogicalExpression::Or(left, right) => {
                         format!("({} || {})", left, right)
                     }
+                    LogicalExpression::Not(e) => {
+                        format!("!({})", e)
+                    }
                 }
             )
         }
@@ -255,6 +259,15 @@ mod tests {
             (
                 "a > 1 || ((b < 2) && (c <= 3)) || d not in \"foo\"",
                 "(((a > 1) || ((b < 2) && (c <= 3))) || (d not in \"foo\"))",
+            ),
+            ("!(a == 1)", "!((a == 1))"),
+            (
+                "!(a == 1) && b == 2 && !(c == 3) && d >= 4",
+                "(((!((a == 1)) && (b == 2)) && !((c == 3))) && (d >= 4))",
+            ),
+            (
+                "!(a == 1 || b == 2 && c == 3) && d == 4",
+                "(!((((a == 1) || (b == 2)) && (c == 3))) && (d == 4))",
             ),
         ];
         for (input, expected) in tests {

--- a/src/atc_grammar.pest
+++ b/src/atc_grammar.pest
@@ -35,9 +35,11 @@ logical_operator = _{ and_op | or_op }
 and_op = { "&&" }
 or_op = { "||" }
 
+not_op = { "!" }
+
 
 predicate = { lhs ~ binary_operator ~ rhs }
-parenthesised_expression = { "(" ~ expression ~ ")" }
+parenthesised_expression = { not_op? ~ "(" ~ expression ~ ")" }
 term = { predicate | parenthesised_expression }
 expression = { term ~ ( logical_operator ~ term )* }
 matcher = { SOI ~ expression ~ EOI }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -11,6 +11,7 @@ impl Execute for Expression {
             Expression::Logical(l) => match l.as_ref() {
                 LogicalExpression::And(l, r) => l.execute(ctx, m) && r.execute(ctx, m),
                 LogicalExpression::Or(l, r) => l.execute(ctx, m) || r.execute(ctx, m),
+                LogicalExpression::Not(r) => !r.execute(ctx, m),
             },
             Expression::Predicate(p) => p.execute(ctx, m),
         }

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -25,6 +25,9 @@ impl FieldCounter for Expression {
                     l.add_to_counter(map);
                     r.add_to_counter(map);
                 }
+                LogicalExpression::Not(r) => {
+                    r.add_to_counter(map);
+                }
             },
             Expression::Predicate(p) => {
                 *map.entry(p.lhs.var_name.clone()).or_default() += 1;
@@ -41,6 +44,9 @@ impl FieldCounter for Expression {
                 }
                 LogicalExpression::Or(l, r) => {
                     l.remove_from_counter(map);
+                    r.remove_from_counter(map);
+                }
+                LogicalExpression::Not(r) => {
                     r.remove_from_counter(map);
                 }
             },
@@ -67,6 +73,9 @@ impl Validate for Expression {
                     }
                     LogicalExpression::Or(l, r) => {
                         l.validate(schema)?;
+                        r.validate(schema)?;
+                    }
+                    LogicalExpression::Not(r) => {
                         r.validate(schema)?;
                     }
                 }

--- a/t/09-not.t
+++ b/t/09-not.t
@@ -1,0 +1,81 @@
+# vim:set ft= ts=4 sw=4 et:
+
+use Test::Nginx::Socket::Lua;
+use Cwd qw(cwd);
+
+repeat_each(2);
+
+plan tests => repeat_each() * blocks() * 5;
+
+my $pwd = cwd();
+
+our $HttpConfig = qq{
+    lua_package_path "$pwd/lib/?.lua;;";
+    lua_package_cpath "$pwd/target/debug/?.so;;";
+};
+
+no_long_string();
+no_diff();
+
+run_tests();
+
+__DATA__
+
+=== TEST 1: not operator negates result from inside expression
+--- http_config eval: $::HttpConfig
+--- config
+    location = /t {
+        content_by_lua_block {
+            local schema = require("resty.router.schema")
+            local router = require("resty.router.router")
+            local context = require("resty.router.context")
+
+            local s = schema.new()
+
+            s:add_field("http.path", "String")
+
+            local r = router.new(s)
+            assert(r:add_matcher(0, "a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c",
+                                 [[!(http.path ^= "/abc")]]))
+
+            local c = context.new(s)
+            c:add_value("http.path", "/abc/d")
+
+            local matched = r:execute(c)
+            ngx.say(matched)
+
+            c:reset()
+
+            c:add_value("http.path", "/abb/d")
+
+            local matched = r:execute(c)
+            ngx.say(matched)
+
+            assert(r:remove_matcher("a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c"))
+            assert(r:add_matcher(0, "a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c",
+                                 [[!(http.path =^ "/")]]))
+
+            c:reset()
+
+            c:add_value("http.path", "/abb/d/")
+            local matched = r:execute(c)
+            ngx.say(matched)
+
+            c:reset()
+
+            c:add_value("http.path", "/abb/d")
+            local matched = r:execute(c)
+            ngx.say(matched)
+        }
+    }
+--- request
+GET /t
+--- response_body
+false
+true
+false
+true
+--- no_error_log
+[error]
+[warn]
+[crit]


### PR DESCRIPTION
The not operator `!` can be used with parenthesized expressions and will negate the result of the expressions.

Pratt parser is not used for this prefix operator because that would make:

```
! a == 1
```

Possible, which may cause confusions. Instead, this was implemented on the parenthesized expressions rule only so you can only write `! (a == 1)`.

[KAG-3605]

[KAG-3605]: https://konghq.atlassian.net/browse/KAG-3605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ