### PR TITLE
perf(lib): add `#[inline]` for small functions

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -72,6 +72,7 @@ impl PartialEq for Value {
 }
 
 impl Value {
+    #[inline]
     pub fn my_type(&self) -> Type {
         match self {
             Value::String(_) => Type::String,
@@ -84,6 +85,7 @@ impl Value {
 }
 
 impl From<String> for Value {
+    #[inline]
     fn from(v: String) -> Self {
         Value::String(v)
     }
@@ -108,10 +110,12 @@ pub struct Lhs {
 }
 
 impl Lhs {
+    #[inline]
     pub fn my_type<'a>(&self, schema: &'a Schema) -> Option<&'a Type> {
         schema.type_of(&self.var_name)
     }
 
+    #[inline]
     pub fn get_transformations(&self) -> (bool, bool) {
         let mut lower = false;
         let mut any = false;

--- a/src/context.rs
+++ b/src/context.rs
@@ -10,6 +10,7 @@ pub struct Match {
 }
 
 impl Match {
+    #[inline]
     pub fn new() -> Self {
         Match {
             uuid: Uuid::default(),
@@ -20,6 +21,7 @@ impl Match {
 }
 
 impl Default for Match {
+    #[inline]
     fn default() -> Self {
         Self::new()
     }
@@ -32,6 +34,7 @@ pub struct Context<'a> {
 }
 
 impl<'a> Context<'a> {
+    #[inline]
     pub fn new(schema: &'a Schema) -> Self {
         Context {
             schema,
@@ -40,6 +43,7 @@ impl<'a> Context<'a> {
         }
     }
 
+    #[inline]
     pub fn add_value(&mut self, field: &str, value: Value) {
         if &value.my_type() != self.schema.type_of(field).unwrap() {
             panic!("value provided does not match schema");
@@ -51,10 +55,12 @@ impl<'a> Context<'a> {
             .push(value);
     }
 
+    #[inline]
     pub fn value_of(&self, field: &str) -> Option<&[Value]> {
         self.values.get(field).map(|v| v.as_slice())
     }
 
+    #[inline]
     pub fn reset(&mut self) {
         self.values.clear();
         self.result = None;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -51,6 +51,7 @@ macro_rules! parse_num {
 }
 
 impl ATCParser {
+    #[inline]
     fn new() -> Self {
         Self {
             pratt_parser: PrattParser::new()
@@ -70,6 +71,7 @@ impl ATCParser {
     }
 }
 
+#[inline]
 fn parse_ident(pair: Pair<Rule>) -> ParseResult<String> {
     Ok(pair.as_str().into())
 }
@@ -123,6 +125,7 @@ fn parse_str_literal(pair: Pair<Rule>) -> ParseResult<String> {
 
 // rawstr_literal = ${ "r#\"" ~ rawstr_char* ~ "\"#" }
 // rawstr_char = { !"\"#" ~ ANY }
+#[inline]
 fn parse_rawstr_literal(pair: Pair<Rule>) -> ParseResult<String> {
     let char_pairs = pair.into_inner();
     let mut s = String::new();
@@ -136,6 +139,7 @@ fn parse_rawstr_literal(pair: Pair<Rule>) -> ParseResult<String> {
     Ok(s)
 }
 
+#[inline]
 fn parse_str_esc(pair: Pair<Rule>) -> char {
     match pair.as_str() {
         r#"\""# => '"',
@@ -147,22 +151,28 @@ fn parse_str_esc(pair: Pair<Rule>) -> char {
         _ => unreachable!(),
     }
 }
+#[inline]
 fn parse_str_char(pair: Pair<Rule>) -> char {
     return pair.as_str().chars().next().unwrap();
 }
+#[inline]
 fn parse_ipv4_cidr_literal(pair: Pair<Rule>) -> ParseResult<Ipv4Cidr> {
     pair.as_str().parse().into_parse_result(&pair)
 }
+#[inline]
 fn parse_ipv6_cidr_literal(pair: Pair<Rule>) -> ParseResult<Ipv6Cidr> {
     pair.as_str().parse().into_parse_result(&pair)
 }
+#[inline]
 fn parse_ipv4_literal(pair: Pair<Rule>) -> ParseResult<Ipv4Addr> {
     pair.as_str().parse().into_parse_result(&pair)
 }
+#[inline]
 fn parse_ipv6_literal(pair: Pair<Rule>) -> ParseResult<Ipv6Addr> {
     pair.as_str().parse().into_parse_result(&pair)
 }
 
+#[inline]
 fn parse_int_literal(pair: Pair<Rule>) -> ParseResult<i64> {
     let is_neg = pair.as_str().starts_with('-');
     let pairs = pair.into_inner();

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -51,7 +51,6 @@ macro_rules! parse_num {
 }
 
 impl ATCParser {
-    #[inline]
     fn new() -> Self {
         Self {
             pratt_parser: PrattParser::new()
@@ -71,7 +70,6 @@ impl ATCParser {
     }
 }
 
-#[inline]
 fn parse_ident(pair: Pair<Rule>) -> ParseResult<String> {
     Ok(pair.as_str().into())
 }
@@ -125,7 +123,6 @@ fn parse_str_literal(pair: Pair<Rule>) -> ParseResult<String> {
 
 // rawstr_literal = ${ "r#\"" ~ rawstr_char* ~ "\"#" }
 // rawstr_char = { !"\"#" ~ ANY }
-#[inline]
 fn parse_rawstr_literal(pair: Pair<Rule>) -> ParseResult<String> {
     let char_pairs = pair.into_inner();
     let mut s = String::new();
@@ -139,7 +136,6 @@ fn parse_rawstr_literal(pair: Pair<Rule>) -> ParseResult<String> {
     Ok(s)
 }
 
-#[inline]
 fn parse_str_esc(pair: Pair<Rule>) -> char {
     match pair.as_str() {
         r#"\""# => '"',
@@ -151,28 +147,22 @@ fn parse_str_esc(pair: Pair<Rule>) -> char {
         _ => unreachable!(),
     }
 }
-#[inline]
 fn parse_str_char(pair: Pair<Rule>) -> char {
     return pair.as_str().chars().next().unwrap();
 }
-#[inline]
 fn parse_ipv4_cidr_literal(pair: Pair<Rule>) -> ParseResult<Ipv4Cidr> {
     pair.as_str().parse().into_parse_result(&pair)
 }
-#[inline]
 fn parse_ipv6_cidr_literal(pair: Pair<Rule>) -> ParseResult<Ipv6Cidr> {
     pair.as_str().parse().into_parse_result(&pair)
 }
-#[inline]
 fn parse_ipv4_literal(pair: Pair<Rule>) -> ParseResult<Ipv4Addr> {
     pair.as_str().parse().into_parse_result(&pair)
 }
-#[inline]
 fn parse_ipv6_literal(pair: Pair<Rule>) -> ParseResult<Ipv6Addr> {
     pair.as_str().parse().into_parse_result(&pair)
 }
 
-#[inline]
 fn parse_int_literal(pair: Pair<Rule>) -> ParseResult<i64> {
     let is_neg = pair.as_str().starts_with('-');
     let pairs = pair.into_inner();

--- a/src/router.rs
+++ b/src/router.rs
@@ -17,6 +17,7 @@ pub struct Router<'a> {
 }
 
 impl<'a> Router<'a> {
+    #[inline]
     pub fn new(schema: &'a Schema) -> Self {
         Self {
             schema,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -7,6 +7,7 @@ pub struct Schema {
 }
 
 impl Schema {
+    #[inline]
     pub fn type_of(&self, field: &str) -> Option<&Type> {
         self.fields.get(field).or_else(|| {
             self.fields
@@ -14,6 +15,7 @@ impl Schema {
         })
     }
 
+    #[inline]
     pub fn add_field(&mut self, field: &str, typ: Type) {
         self.fields.insert(field.to_string(), typ);
     }


### PR DESCRIPTION
`#[inline]` on function can tell compiler to automatically expand the function at the places where it's used. The cost is that the the compiled binary file will become larger, and the compilation time might increase. But in general experience the trade-off are usually worth it for small function.

Below is the benchmark result of a hot spot function `Predicate::Execute` method, with efficiency improved by nearly 6.7%, in macOS on Apple M1 Pro (10-core, 32GB RAM).
```
time:   [6.4486 ns 6.4725 ns 6.5054 ns]
change: [-12.594% -6.7029% -2.1903%] (p = 0.01 < 0.05)
Performance has improved.
```

The benchmark source code

```rust
fn criterion_benchmark(c: &mut Criterion) {
    let mut schema = schema::Schema::default();
    schema.add_field("my_key", ast::Type::String);

    let p = Predicate {
        lhs: ast::Lhs {
            var_name: "my_key".to_string(),
            transformations: vec![],
        },
        rhs: Value::String("foo".to_string()),
        op: BinaryOperator::Prefix,
    };

    c.bench_function("Predicate::execute", |b| {
        b.iter(|| {
            let mut ctx = Context::new(&schema);
            let mut mat = Match::new();
            p.execute(&mut ctx, &mut mat)
        })
    });
}
```
