### PR TITLE
perf(parser): cache regex predicates with rc using thread_local

### DIFF
--- a/src/ast.rs
+++ b/src/ast.rs
@@ -1,7 +1,7 @@
 use crate::schema::Schema;
 use cidr::IpCidr;
 use regex::Regex;
-use std::net::IpAddr;
+use std::{net::IpAddr, rc::Rc};
 
 #[cfg(feature = "serde")]
 use serde::{Deserialize, Serialize};
@@ -53,7 +53,7 @@ pub enum Value {
     IpAddr(IpAddr),
     Int(i64),
     #[cfg_attr(feature = "serde", serde(with = "serde_regex"))]
-    Regex(Regex),
+    Regex(Rc<Regex>),
 }
 
 impl PartialEq for Value {


### PR DESCRIPTION
### Description

This PR is one out of 3 proposed approaches how to optimize memory consumption for specific edge case with ATC Router. The scenario that is being considered is a Router that's defined with the same regular expression in different predicates. Currently Router does not have any ability to remember the regex passed resulting in a lot of copies of the same regex.

### Approach in this PR

This PR introduces singleton pattern in a variable `REGEX_CACHE` that is stored using `thread_local` macro. This macro allows only for immutable values ([more](https://doc.rust-lang.org/std/macro.thread_local.html#:~:text=Note%20that%20only%20shared%20references%20(%26T)%20to%20the%20inner%20data%20may%20be%20obtained%2C%20so%20a%20type%20such%20as%20Cell%20or%20RefCell%20is%20typically%20used%20to%20allow%20mutating%20access.)) so in order to provide mutability (storing new keys in hashmap) I needed to use [_interior mutability_](https://doc.rust-lang.org/book/ch15-05-interior-mutability.html#refcellt-and-the-interior-mutability-pattern) pattern using `RefCell`.

### Benchmarks

The benchmarking method was to use the commit in this PR: https://github.com/Kong/atc-router/pull/253 on top of each of these PRs. The memory benchmark was done using [dhat](https://github.com/nnethercote/dhat-rs) crate and performance was measured with [criterion](https://github.com/bheisler/criterion.rs) crate.

#### Memory consumption:
|                                                       | Baseline (main)  | Router attribute (#251) | Thread local (**this**) | Memoize (#252) |
| ------------------------------- | ---------------- | -------------------------- | ------------------- | ----------------- |
| Total (human-readable)             |  4.54 GB 🔴  | 242.5 MB 🏆  | 242.5 MB     🏆      | 299.6 MB |
| Total (exact)                                | 4,544,275,926 bytes in 6,762,329 blocks | 242,508,176 bytes in 1,922,359 blocks | 242,508,176 bytes in 1,922,359 blocks | 299,608,085 bytes in 1,962,821 blocks  |
| At t-gmax                                      | 194,867,606 bytes in 382,216 blocks | 4,713,936 bytes in 41,863 blocks | 4,713,936 bytes in 41,863 block               | 60,538,606 bytes in 72,258 blocks |
| At t-end                                         | 0 bytes in 0 blocks | 0 bytes in 0 blocks | 108,034 bytes in 168 blocks               | 35,671,000 bytes in 42 blocks |


#### Performance:

| Baseline (main)  | Router attribute (#251) | Thread local (**this**) | Memoize (#252) |
| ---------------- | -------------------------- | ------------------- | ----------------- |
| 660.68 ms  🔴   | 78.834 ms       :trophy:       | 80.695 ms               | 86.169 ms |


### Other PRs Links:

- https://github.com/Kong/atc-router/pull/251
- (this) https://github.com/Kong/atc-router/pull/250
- https://github.com/Kong/atc-router/pull/252

### Issue reference:

KAG-3182