### PR TITLE
perf(parser): memoize parsed regular expressions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,17 @@
 version = 3
 
 [[package]]
+name = "ahash"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "891477e0c6a8957309ee5c45a6368af3ae14bb510732d2684ffa19af310920f9"
+dependencies = [
+ "getrandom",
+ "once_cell",
+ "version_check",
+]
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -18,6 +29,7 @@ dependencies = [
  "cidr",
  "fnv",
  "lazy_static",
+ "memoize",
  "pest",
  "pest_derive",
  "regex",
@@ -96,6 +108,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "getrandom"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94b22e06ecb0110981051723910cbf0b5f5e09a2062dd7663334ee79a9d1286c"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
+dependencies = [
+ "ahash",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -108,10 +140,42 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
+name = "lru"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999beba7b6e8345721bd280141ed958096a2e4abdf74f67ff4ce49b4b54e47a"
+dependencies = [
+ "hashbrown",
+]
+
+[[package]]
 name = "memchr"
 version = "2.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c8640c5d730cb13ebd907d8d04b52f55ac9a2eec55b440c8892f40d56c76c1d"
+
+[[package]]
+name = "memoize"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5df4051db13d0816cf23196d3baa216385ae099339f5d0645a8d9ff2305e82b8"
+dependencies = [
+ "lazy_static",
+ "lru",
+ "memoize-inner",
+]
+
+[[package]]
+name = "memoize-inner"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bdece7e91f0d1e33df7b46ec187a93ea0d4e642113a1039ac8bfdd4a3273ac"
+dependencies = [
+ "lazy_static",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "once_cell"
@@ -150,7 +214,7 @@ dependencies = [
  "pest_meta",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -228,7 +292,7 @@ checksum = "7eb0b34b42edc17f6b7cac84a52a1c5f0e1bb2227e997ca9011ea3dd34e8610b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -250,6 +314,17 @@ dependencies = [
  "cfg-if",
  "cpufeatures",
  "digest",
+]
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -280,7 +355,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.59",
 ]
 
 [[package]]
@@ -312,3 +387,9 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "wasi"
+version = "0.11.0+wasi-snapshot-preview1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ regex = "1"
 serde = { version = "1.0", features = ["derive"], optional = true }
 serde_regex = { version = "1.1", optional = true }
 fnv = "1"
+memoize = "0.4.0"
 
 [lib]
 crate-type = ["lib", "cdylib", "staticlib"]


### PR DESCRIPTION
### Description

This PR is one out of 3 proposed approaches how to optimize memory consumption for specific edge case with ATC Router. The scenario that is being considered is a Router that's defined with the same regular expression in different predicates. Currently Router does not have any ability to remember the regex passed resulting in a lot of copies of the same regex.

### Approach in this PR

This PR recycles the approach proposed by @hanshuebner in: https://github.com/Kong/atc-router/pull/141

> Parsing regular expressions can take significant time in large configurations.  With this change, regular expression parse results are memoized to avoid needless re-parsing.  The memoization table is bounded to 1000000 entries to avoid memory exhaustion in the unlikely case that a router process sees a huge number of different regular expressions during its lifetime.

### Benchmarks

The benchmarking method was to use the commit in this PR: https://github.com/Kong/atc-router/pull/253 on top of each of these PRs. The memory benchmark was done using [dhat](https://github.com/nnethercote/dhat-rs) crate and performance was measured with [criterion](https://github.com/bheisler/criterion.rs) crate.

#### Memory consumption:
|                                                       | Baseline (main)  | Router attribute (#251) | Thread local (#250) | Memoize (**this**) |
| ------------------------------- | ---------------- | -------------------------- | ------------------- | ----------------- |
| Total (human-readable)             |  4.54 GB 🔴  | 242.5 MB 🏆  | 242.5 MB     🏆      | 299.6 MB |
| Total (exact)                                | 4,544,275,926 bytes in 6,762,329 blocks | 242,508,176 bytes in 1,922,359 blocks | 242,508,176 bytes in 1,922,359 blocks | 299,608,085 bytes in 1,962,821 blocks  |
| At t-gmax                                      | 194,867,606 bytes in 382,216 blocks | 4,713,936 bytes in 41,863 blocks | 4,713,936 bytes in 41,863 block               | 60,538,606 bytes in 72,258 blocks |
| At t-end                                         | 0 bytes in 0 blocks | 0 bytes in 0 blocks | 108,034 bytes in 168 blocks               | 35,671,000 bytes in 42 blocks |


#### Performance:

| Baseline (main)  | Router attribute (#251) | Thread local (#250) | Memoize (**this**) |
| ---------------- | -------------------------- | ------------------- | ----------------- |
| 660.68 ms  🔴   | 78.834 ms       :trophy:       | 80.695 ms               | 86.169 ms |


### Other PRs Links:

- https://github.com/Kong/atc-router/pull/251
- https://github.com/Kong/atc-router/pull/250
- (this) https://github.com/Kong/atc-router/pull/252

### Issue reference:

KAG-3182