### PR TITLE
chore(cargo): remove unsupported slug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ Versatile DSL based rule matching engine used by the Kong API Gateway
 """
 repository = "https://github.com/Kong/atc-router"
 keywords = ["dsl", "atc", "router", "rule", "engine"]
-categories = ["Compilers", "Parser implementations"]
+categories = ["compilers"]
 
 [dependencies]
 pest = "2.7"


### PR DESCRIPTION
```
error: failed to publish to registry at https://crates.io

Caused by:
  the remote server responded with an error (status 400 Bad Request): The following category slugs are not currently supported on crates.io: Compilers, Parser implementations

  See https://crates.io/category_slugs for a list of supported slugs.
```