### PR TITLE
feat(interpreter): use the immutable reference of `Context` in the `execute` method

### DIFF
--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -2,11 +2,11 @@ use crate::ast::{BinaryOperator, Expression, LogicalExpression, Predicate, Value
 use crate::context::{Context, Match};
 
 pub trait Execute {
-    fn execute(&self, ctx: &mut Context, m: &mut Match) -> bool;
+    fn execute(&self, ctx: &Context, m: &mut Match) -> bool;
 }
 
 impl Execute for Expression {
-    fn execute(&self, ctx: &mut Context, m: &mut Match) -> bool {
+    fn execute(&self, ctx: &Context, m: &mut Match) -> bool {
         match self {
             Expression::Logical(l) => match l.as_ref() {
                 LogicalExpression::And(l, r) => l.execute(ctx, m) && r.execute(ctx, m),
@@ -19,7 +19,7 @@ impl Execute for Expression {
 }
 
 impl Execute for Predicate {
-    fn execute(&self, ctx: &mut Context, m: &mut Match) -> bool {
+    fn execute(&self, ctx: &Context, m: &mut Match) -> bool {
         let lhs_values = match ctx.value_of(&self.lhs.var_name) {
             None => return false,
             Some(v) => v,
@@ -292,7 +292,7 @@ fn test_predicate() {
         op: BinaryOperator::Prefix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), false);
+    assert_eq!(p.execute(&ctx, &mut mat), false);
 
     // check if any value matches starts_with foo -- should be false
     let p = Predicate {
@@ -304,7 +304,7 @@ fn test_predicate() {
         op: BinaryOperator::Prefix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), false);
+    assert_eq!(p.execute(&ctx, &mut mat), false);
 
     // test any mode
     let lhs_values = vec![
@@ -328,7 +328,7 @@ fn test_predicate() {
         op: BinaryOperator::Prefix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), true);
+    assert_eq!(p.execute(&ctx, &mut mat), true);
 
     // check if all values match ends_with foo -- should be false
     let p = Predicate {
@@ -340,7 +340,7 @@ fn test_predicate() {
         op: BinaryOperator::Postfix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), false);
+    assert_eq!(p.execute(&ctx, &mut mat), false);
 
     // check if any value matches ends_with foo -- should be true
     let p = Predicate {
@@ -352,7 +352,7 @@ fn test_predicate() {
         op: BinaryOperator::Postfix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), true);
+    assert_eq!(p.execute(&ctx, &mut mat), true);
 
     // check if any value matches starts_with foo -- should be true
     let p = Predicate {
@@ -364,7 +364,7 @@ fn test_predicate() {
         op: BinaryOperator::Prefix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), true);
+    assert_eq!(p.execute(&ctx, &mut mat), true);
 
     // check if any value matches ends_with nar -- should be false
     let p = Predicate {
@@ -376,7 +376,7 @@ fn test_predicate() {
         op: BinaryOperator::Postfix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), false);
+    assert_eq!(p.execute(&ctx, &mut mat), false);
 
     // check if any value matches ends_with empty string -- should be true
     let p = Predicate {
@@ -388,7 +388,7 @@ fn test_predicate() {
         op: BinaryOperator::Postfix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), true);
+    assert_eq!(p.execute(&ctx, &mut mat), true);
 
     // check if any value matches starts_with empty string -- should be true
     let p = Predicate {
@@ -400,7 +400,7 @@ fn test_predicate() {
         op: BinaryOperator::Prefix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), true);
+    assert_eq!(p.execute(&ctx, &mut mat), true);
 
     // check if any value matches contains `ob` -- should be true
     let p = Predicate {
@@ -412,7 +412,7 @@ fn test_predicate() {
         op: BinaryOperator::Contains,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), true);
+    assert_eq!(p.execute(&ctx, &mut mat), true);
 
     // check if any value matches contains `ok` -- should be false
     let p = Predicate {
@@ -424,5 +424,5 @@ fn test_predicate() {
         op: BinaryOperator::Contains,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), false);
+    assert_eq!(p.execute(&ctx, &mut mat), false);
 }


### PR DESCRIPTION
Unless I'm missing something or there's some planned feature, the `&Context` doesn't need to be `mut`