### PR TITLE
feat: derive `Debug` for all public types

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -3,6 +3,7 @@ use crate::schema::Schema;
 use fnv::FnvHashMap;
 use uuid::Uuid;
 
+#[derive(Debug)]
 pub struct Match {
     pub uuid: Uuid,
     pub matches: FnvHashMap<String, Value>,
@@ -25,6 +26,7 @@ impl Default for Match {
     }
 }
 
+#[derive(Debug)]
 pub struct Context<'a> {
     schema: &'a Schema,
     values: FnvHashMap<String, Vec<Value>>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+#![deny(warnings, missing_debug_implementations)]
 /*!
 This crate provides a powerful rule based matching engine that can match a set of routes
 against dynamic input value efficiently.

--- a/src/router.rs
+++ b/src/router.rs
@@ -7,9 +7,10 @@ use crate::semantics::{FieldCounter, Validate};
 use std::collections::{BTreeMap, HashMap};
 use uuid::Uuid;
 
-#[derive(PartialEq, Eq, PartialOrd, Ord)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
 struct MatcherKey(usize, Uuid);
 
+#[derive(Debug)]
 pub struct Router<'a> {
     schema: &'a Schema,
     matchers: BTreeMap<MatcherKey, Expression>,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,7 +1,7 @@
 use crate::ast::Type;
 use std::collections::HashMap;
 
-#[derive(Default)]
+#[derive(Debug, Default)]
 pub struct Schema {
     fields: HashMap<String, Type>,
 }


### PR DESCRIPTION
According to [`std::fmt` docs](https://doc.rust-lang.org/stable/std/fmt/index.html#fmtdisplay-vs-fmtdebug) this should be implemented for all public types.