### PR TITLE
chore: run cargo clippy --fix

### DIFF
--- a/src/ffi/expression.rs
+++ b/src/ffi/expression.rs
@@ -143,7 +143,6 @@ pub const ATC_ROUTER_EXPRESSION_VALIDATE_BUF_TOO_SMALL: i64 = 2;
 /// - `operators` must be a valid pointer to write `size_of::<u64>()` bytes and properly aligned.
 /// - `errbuf` must be valid for reading and writing `errbuf_len * size_of::<u8>()` bytes and properly aligned.
 /// - `errbuf_len` must be a valid pointer for reading and writing `size_of::<usize>()` bytes and properly aligned.
-
 #[no_mangle]
 pub unsafe extern "C" fn expression_validate(
     atc: *const u8,
@@ -241,7 +240,7 @@ mod tests {
         let result = unsafe {
             expression_validate(
                 atc.as_bytes().as_ptr(),
-                &schema,
+                schema,
                 fields_buf.as_mut_ptr(),
                 &mut fields_buf_len,
                 &mut fields_total,

--- a/src/ffi/router.rs
+++ b/src/ffi/router.rs
@@ -258,7 +258,7 @@ mod tests {
                 errbuf.as_mut_ptr(),
                 &mut errbuf_len,
             );
-            assert_eq!(result, false);
+            assert!(!result);
             assert_eq!(errbuf_len, ERR_BUF_MAX_LEN);
         }
     }
@@ -281,7 +281,7 @@ mod tests {
                 errbuf.as_mut_ptr(),
                 &mut errbuf_len,
             );
-            assert_eq!(result, false);
+            assert!(!result);
             assert!(errbuf_len < ERR_BUF_MAX_LEN);
         }
     }

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -292,7 +292,7 @@ fn test_predicate() {
         op: BinaryOperator::Prefix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), false);
+    assert!(!p.execute(&mut ctx, &mut mat));
 
     // check if any value matches starts_with foo -- should be false
     let p = Predicate {
@@ -304,7 +304,7 @@ fn test_predicate() {
         op: BinaryOperator::Prefix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), false);
+    assert!(!p.execute(&mut ctx, &mut mat));
 
     // test any mode
     let lhs_values = vec![
@@ -328,7 +328,7 @@ fn test_predicate() {
         op: BinaryOperator::Prefix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), true);
+    assert!(p.execute(&mut ctx, &mut mat));
 
     // check if all values match ends_with foo -- should be false
     let p = Predicate {
@@ -340,7 +340,7 @@ fn test_predicate() {
         op: BinaryOperator::Postfix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), false);
+    assert!(!p.execute(&mut ctx, &mut mat));
 
     // check if any value matches ends_with foo -- should be true
     let p = Predicate {
@@ -352,7 +352,7 @@ fn test_predicate() {
         op: BinaryOperator::Postfix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), true);
+    assert!(p.execute(&mut ctx, &mut mat));
 
     // check if any value matches starts_with foo -- should be true
     let p = Predicate {
@@ -364,7 +364,7 @@ fn test_predicate() {
         op: BinaryOperator::Prefix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), true);
+    assert!(p.execute(&mut ctx, &mut mat));
 
     // check if any value matches ends_with nar -- should be false
     let p = Predicate {
@@ -376,7 +376,7 @@ fn test_predicate() {
         op: BinaryOperator::Postfix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), false);
+    assert!(!p.execute(&mut ctx, &mut mat));
 
     // check if any value matches ends_with empty string -- should be true
     let p = Predicate {
@@ -388,7 +388,7 @@ fn test_predicate() {
         op: BinaryOperator::Postfix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), true);
+    assert!(p.execute(&mut ctx, &mut mat));
 
     // check if any value matches starts_with empty string -- should be true
     let p = Predicate {
@@ -400,7 +400,7 @@ fn test_predicate() {
         op: BinaryOperator::Prefix,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), true);
+    assert!(p.execute(&mut ctx, &mut mat));
 
     // check if any value matches contains `ob` -- should be true
     let p = Predicate {
@@ -412,7 +412,7 @@ fn test_predicate() {
         op: BinaryOperator::Contains,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), true);
+    assert!(p.execute(&mut ctx, &mut mat));
 
     // check if any value matches contains `ok` -- should be false
     let p = Predicate {
@@ -424,5 +424,5 @@ fn test_predicate() {
         op: BinaryOperator::Contains,
     };
 
-    assert_eq!(p.execute(&mut ctx, &mut mat), false);
+    assert!(!p.execute(&mut ctx, &mut mat));
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -14,9 +14,9 @@ use regex::Regex;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 type ParseResult<T> = Result<T, ParseError<Rule>>;
+
 /// cbindgen:ignore
 // Bug: https://github.com/eqrion/cbindgen/issues/286
-
 trait IntoParseResult<T> {
     #[allow(clippy::result_large_err)] // it's fine as parsing is not the hot path
     fn into_parse_result(self, pair: &Pair<Rule>) -> ParseResult<T>;
@@ -157,7 +157,7 @@ fn parse_str_esc(pair: Pair<Rule>) -> char {
     }
 }
 fn parse_str_char(pair: Pair<Rule>) -> char {
-    return pair.as_str().chars().next().unwrap();
+    pair.as_str().chars().next().unwrap()
 }
 
 #[allow(clippy::result_large_err)] // it's fine as parsing is not the hot path


### PR DESCRIPTION
Manually removed the two empty lines but doesn't seem to have affected code generation. But generation doesn't seem to be part of CI so I'm not sure what's the state of it.