### PR TITLE
chore(ci): bump to ubuntu-22.04 and OpenResty matrix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,11 +14,13 @@ concurrency:
 jobs:
   tests:
     name: Tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       matrix:
         openresty:
+          - '1.27.1.2'
+          - '1.27.1.1'
           - '1.25.3.2'
           - '1.25.3.1'
           - '1.21.4.4'


### PR DESCRIPTION
update to ubuntu 22.04 and OpenResty 1.27.1.x
KAG-6866