### PR TITLE
refactor(src): code clean for semantics

### DIFF
--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -97,6 +97,11 @@ impl Validate for Expression {
                 Ok(())
             }
             Predicate(p) => {
+                use BinaryOperator::{
+                    Contains, Equals, Greater, GreaterOrEqual, In, Less, LessOrEqual, NotEquals,
+                    NotIn, Postfix, Prefix, Regex,
+                };
+
                 // lhs and rhs must be the same type
                 let Some(lhs_type) = p.lhs.my_type(schema) else {
                     return raise_err(MSG_UNKNOWN_LHS);
@@ -116,11 +121,6 @@ impl Validate for Expression {
                 if lower && lhs_type != &Type::String {
                     return raise_err(MSG_LOWER_ONLY_FOR_STRING);
                 }
-
-                use BinaryOperator::{
-                    Contains, Equals, Greater, GreaterOrEqual, In, Less, LessOrEqual, NotEquals,
-                    NotIn, Postfix, Prefix, Regex,
-                };
 
                 match p.op {
                     Equals | NotEquals => Ok(()),

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -147,10 +147,10 @@ impl Validate for Expression {
                         Value::String(_) => Ok(()),
                         _ => raise_err(MSG_CONTAINS_ONLY_FOR_CIDR),
                     },
-                }
-            }
-        }
-    }
+                } // match p.op
+            } // Predicate(p)
+        } // match self
+    } // fn validate
 }
 
 #[cfg(test)]

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -59,11 +59,7 @@ impl Validate for Expression {
         match self {
             Expression::Logical(l) => {
                 match l.as_ref() {
-                    LogicalExpression::And(l, r) => {
-                        l.validate(schema)?;
-                        r.validate(schema)?;
-                    }
-                    LogicalExpression::Or(l, r) => {
+                    LogicalExpression::And(l, r) | LogicalExpression::Or(l, r) => {
                         l.validate(schema)?;
                         r.validate(schema)?;
                     }
@@ -76,11 +72,9 @@ impl Validate for Expression {
             }
             Expression::Predicate(p) => {
                 // lhs and rhs must be the same type
-                let lhs_type = p.lhs.my_type(schema);
-                if lhs_type.is_none() {
+                let Some(lhs_type) = p.lhs.my_type(schema) else {
                     return Err("Unknown LHS field".to_string());
-                }
-                let lhs_type = lhs_type.unwrap();
+                };
 
                 if p.op != BinaryOperator::Regex // Regex RHS is always Regex, and LHS is always String
                     && p.op != BinaryOperator::In // In/NotIn supports IPAddr in IpCidr

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -54,6 +54,10 @@ impl FieldCounter for Expression {
     }
 }
 
+fn raise_err(msg: &str) -> ValidationResult {
+    return Err(msg.to_string())
+}
+
 impl Validate for Expression {
     fn validate(&self, schema: &Schema) -> ValidationResult {
         match self {
@@ -81,19 +85,15 @@ impl Validate for Expression {
                     && p.op != BinaryOperator::NotIn
                     && lhs_type != &p.rhs.my_type()
                 {
-                    return Err(
-                        "Type mismatch between the LHS and RHS values of predicate".to_string()
-                    );
+                    return raise_err("Type mismatch between the LHS and RHS values of predicate");
                 }
 
                 let (lower, _any) = p.lhs.get_transformations();
 
                 // LHS transformations only makes sense with string fields
                 if lower && lhs_type != &Type::String {
-                    return Err(
-                        "lower-case transformation function only supported with String type fields"
-                            .to_string(),
-                    );
+                    return raise_err(
+                        "lower-case transformation function only supported with String type fields");
                 }
 
                 match p.op {
@@ -103,7 +103,7 @@ impl Validate for Expression {
                         if lhs_type == &Type::String {
                             Ok(())
                         } else {
-                            Err("Regex operators only supports string operands".to_string())
+                            raise_err("Regex operators only supports string operands")
                         }
                     },
                     BinaryOperator::Prefix | BinaryOperator::Postfix => {
@@ -111,7 +111,7 @@ impl Validate for Expression {
                             Value::String(_) => {
                                 Ok(())
                             }
-                            _ => Err("Regex/Prefix/Postfix operators only supports string operands".to_string())
+                            _ => raise_err("Regex/Prefix/Postfix operators only supports string operands")
                         }
                     },
                     BinaryOperator::Greater | BinaryOperator::GreaterOrEqual | BinaryOperator::Less | BinaryOperator::LessOrEqual => {
@@ -119,7 +119,7 @@ impl Validate for Expression {
                             Value::Int(_) => {
                                 Ok(())
                             }
-                            _ => Err("Greater/GreaterOrEqual/Lesser/LesserOrEqual operators only supports integer operands".to_string())
+                            _ => raise_err("Greater/GreaterOrEqual/Lesser/LesserOrEqual operators only supports integer operands")
                         }
                     },
                     BinaryOperator::In | BinaryOperator::NotIn => {
@@ -128,7 +128,7 @@ impl Validate for Expression {
                             (Type::IpAddr, Value::IpCidr(_)) => {
                                 Ok(())
                             }
-                            _ => Err("In/NotIn operators only supports IP in CIDR".to_string())
+                            _ => raise_err("In/NotIn operators only supports IP in CIDR")
                         }
                     },
                     BinaryOperator::Contains => {
@@ -136,7 +136,7 @@ impl Validate for Expression {
                             Value::String(_) => {
                                 Ok(())
                             }
-                            _ => Err("Contains operator only supports string operands".to_string())
+                            _ => raise_err("Contains operator only supports string operands")
                         }
                     }
                 }

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -17,11 +17,7 @@ impl FieldCounter for Expression {
     fn add_to_counter(&self, map: &mut HashMap<String, usize>) {
         match self {
             Expression::Logical(l) => match l.as_ref() {
-                LogicalExpression::And(l, r) => {
-                    l.add_to_counter(map);
-                    r.add_to_counter(map);
-                }
-                LogicalExpression::Or(l, r) => {
+                LogicalExpression::And(l, r) | LogicalExpression::Or(l, r) => {
                     l.add_to_counter(map);
                     r.add_to_counter(map);
                 }
@@ -38,11 +34,7 @@ impl FieldCounter for Expression {
     fn remove_from_counter(&self, map: &mut HashMap<String, usize>) {
         match self {
             Expression::Logical(l) => match l.as_ref() {
-                LogicalExpression::And(l, r) => {
-                    l.remove_from_counter(map);
-                    r.remove_from_counter(map);
-                }
-                LogicalExpression::Or(l, r) => {
+                LogicalExpression::And(l, r) | LogicalExpression::Or(l, r) => {
                     l.remove_from_counter(map);
                     r.remove_from_counter(map);
                 }

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -16,8 +16,8 @@ pub trait FieldCounter {
 
 impl FieldCounter for Expression {
     fn add_to_counter(&self, map: &mut ValidationHashMap) {
-        use Expression::*;
-        use LogicalExpression::*;
+        use Expression::{Logical, Predicate};
+        use LogicalExpression::{And, Not, Or};
 
         match self {
             Logical(l) => match l.as_ref() {
@@ -36,8 +36,8 @@ impl FieldCounter for Expression {
     }
 
     fn remove_from_counter(&self, map: &mut ValidationHashMap) {
-        use Expression::*;
-        use LogicalExpression::*;
+        use Expression::{Logical, Predicate};
+        use LogicalExpression::{And, Not, Or};
 
         match self {
             Logical(l) => match l.as_ref() {
@@ -79,8 +79,8 @@ const MSG_CONTAINS_ONLY_FOR_CIDR: &str = "Contains operator only supports string
 
 impl Validate for Expression {
     fn validate(&self, schema: &Schema) -> ValidationResult {
-        use Expression::*;
-        use LogicalExpression::*;
+        use Expression::{Logical, Predicate};
+        use LogicalExpression::{And, Not, Or};
 
         match self {
             Logical(l) => {
@@ -97,7 +97,10 @@ impl Validate for Expression {
                 Ok(())
             }
             Predicate(p) => {
-                use BinaryOperator::*;
+                use BinaryOperator::{
+                    Contains, Equals, Greater, GreaterOrEqual, In, Less, LessOrEqual, NotEquals,
+                    NotIn, Postfix, Prefix, Regex,
+                };
 
                 // lhs and rhs must be the same type
                 let Some(lhs_type) = p.lhs.my_type(schema) else {

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -93,7 +93,7 @@ impl Validate for Expression {
                 // LHS transformations only makes sense with string fields
                 if lower && lhs_type != &Type::String {
                     return raise_err(
-                        "lower-case transformation function only supported with String type fields"
+                        "lower-case transformation function only supported with String type fields",
                     );
                 }
 

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -77,7 +77,7 @@ impl Validate for Expression {
             Expression::Predicate(p) => {
                 // lhs and rhs must be the same type
                 let Some(lhs_type) = p.lhs.my_type(schema) else {
-                    return Err("Unknown LHS field".to_string());
+                    return raise_err("Unknown LHS field");
                 };
 
                 if p.op != BinaryOperator::Regex // Regex RHS is always Regex, and LHS is always String

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -55,7 +55,7 @@ impl FieldCounter for Expression {
 }
 
 fn raise_err(msg: &str) -> ValidationResult {
-    return Err(msg.to_string())
+    Err(msg.to_string())
 }
 
 impl Validate for Expression {
@@ -93,7 +93,8 @@ impl Validate for Expression {
                 // LHS transformations only makes sense with string fields
                 if lower && lhs_type != &Type::String {
                     return raise_err(
-                        "lower-case transformation function only supported with String type fields");
+                        "lower-case transformation function only supported with String type fields"
+                    );
                 }
 
                 match p.op {
@@ -105,7 +106,7 @@ impl Validate for Expression {
                         } else {
                             raise_err("Regex operators only supports string operands")
                         }
-                    },
+                    }
                     BinaryOperator::Prefix | BinaryOperator::Postfix => {
                         match p.rhs {
                             Value::String(_) => {
@@ -113,7 +114,7 @@ impl Validate for Expression {
                             }
                             _ => raise_err("Regex/Prefix/Postfix operators only supports string operands")
                         }
-                    },
+                    }
                     BinaryOperator::Greater | BinaryOperator::GreaterOrEqual | BinaryOperator::Less | BinaryOperator::LessOrEqual => {
                         match p.rhs {
                             Value::Int(_) => {
@@ -121,7 +122,7 @@ impl Validate for Expression {
                             }
                             _ => raise_err("Greater/GreaterOrEqual/Lesser/LesserOrEqual operators only supports integer operands")
                         }
-                    },
+                    }
                     BinaryOperator::In | BinaryOperator::NotIn => {
                         // unchecked path above
                         match (lhs_type, &p.rhs,) {
@@ -130,7 +131,7 @@ impl Validate for Expression {
                             }
                             _ => raise_err("In/NotIn operators only supports IP in CIDR")
                         }
-                    },
+                    }
                     BinaryOperator::Contains => {
                         match p.rhs {
                             Value::String(_) => {

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -112,10 +112,11 @@ impl Validate for Expression {
                     Equals | NotEquals => { Ok(()) }
                     Regex => {
                         // unchecked path above
-                        if lhs_type == &Type::String {
-                            Ok(())
-                        } else {
-                            raise_err("Regex operators only supports string operands")
+                        match lhs_type {
+                          Type::String => {
+                              Ok(())
+                          }
+                          _ => raise_err("Regex operators only supports string operands")
                         }
                     }
                     Prefix | Postfix => {

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -64,22 +64,17 @@ fn raise_err(msg: &str) -> ValidationResult {
     Err(msg.to_string())
 }
 
-const MSG_UNKNOWN_LHS: &str =
-    "Unknown LHS field";
-const MSG_TYPE_MISMATCH_LHS_RHS: &str =
-    "Type mismatch between the LHS and RHS values of predicate";
+const MSG_UNKNOWN_LHS: &str = "Unknown LHS field";
+const MSG_TYPE_MISMATCH_LHS_RHS: &str = "Type mismatch between the LHS and RHS values of predicate";
 const MSG_LOWER_ONLY_FOR_STRING: &str =
     "lower-case transformation function only supported with String type fields";
-const MSG_REGEX_ONLY_FOR_STRING: &str =
-    "Regex operators only supports string operands";
+const MSG_REGEX_ONLY_FOR_STRING: &str = "Regex operators only supports string operands";
 const MSG_PREFFIX_POSTFIX_ONLY_FOR_STRING: &str =
     "Prefix/Postfix operators only supports string operands";
 const MSG_ONLY_FOR_INT: &str =
     "Greater/GreaterOrEqual/Less/LessOrEqual operators only supports integer operands";
-const MSG_ONLY_FOR_CIDR: &str =
-    "In/NotIn operators only supports IP in CIDR";
-const MSG_CONTAINS_ONLY_FOR_CIDR: &str =
-    "Contains operator only supports string operands";
+const MSG_ONLY_FOR_CIDR: &str = "In/NotIn operators only supports IP in CIDR";
+const MSG_CONTAINS_ONLY_FOR_CIDR: &str = "Contains operator only supports string operands";
 
 impl Validate for Expression {
     fn validate(&self, schema: &Schema) -> ValidationResult {
@@ -124,49 +119,33 @@ impl Validate for Expression {
                 }
 
                 match p.op {
-                    Equals | NotEquals => { Ok(()) }
+                    Equals | NotEquals => Ok(()),
                     Regex => {
                         // unchecked path above
                         match lhs_type {
-                          Type::String => {
-                              Ok(())
-                          }
-                          _ => raise_err(MSG_REGEX_ONLY_FOR_STRING)
+                            Type::String => Ok(()),
+                            _ => raise_err(MSG_REGEX_ONLY_FOR_STRING),
                         }
                     }
-                    Prefix | Postfix => {
-                        match p.rhs {
-                            Value::String(_) => {
-                                Ok(())
-                            }
-                            _ => raise_err(MSG_PREFFIX_POSTFIX_ONLY_FOR_STRING)
-                        }
-                    }
-                    Greater | GreaterOrEqual | Less | LessOrEqual => {
-                        match p.rhs {
-                            Value::Int(_) => {
-                                Ok(())
-                            }
-                            _ => raise_err(MSG_ONLY_FOR_INT)
-                        }
-                    }
+                    Prefix | Postfix => match p.rhs {
+                        Value::String(_) => Ok(()),
+                        _ => raise_err(MSG_PREFFIX_POSTFIX_ONLY_FOR_STRING),
+                    },
+                    Greater | GreaterOrEqual | Less | LessOrEqual => match p.rhs {
+                        Value::Int(_) => Ok(()),
+                        _ => raise_err(MSG_ONLY_FOR_INT),
+                    },
                     In | NotIn => {
                         // unchecked path above
-                        match (lhs_type, &p.rhs,) {
-                            (Type::IpAddr, Value::IpCidr(_)) => {
-                                Ok(())
-                            }
-                            _ => raise_err(MSG_ONLY_FOR_CIDR)
+                        match (lhs_type, &p.rhs) {
+                            (Type::IpAddr, Value::IpCidr(_)) => Ok(()),
+                            _ => raise_err(MSG_ONLY_FOR_CIDR),
                         }
                     }
-                    Contains => {
-                        match p.rhs {
-                            Value::String(_) => {
-                                Ok(())
-                            }
-                            _ => raise_err(MSG_CONTAINS_ONLY_FOR_CIDR)
-                        }
-                    }
+                    Contains => match p.rhs {
+                        Value::String(_) => Ok(()),
+                        _ => raise_err(MSG_CONTAINS_ONLY_FOR_CIDR),
+                    },
                 }
             }
         }

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -70,7 +70,7 @@ const MSG_TYPE_MISMATCH_LHS_RHS: &str = "Type mismatch between the LHS and RHS v
 const MSG_LOWER_ONLY_FOR_STRING: &str =
     "lower-case transformation function only supported with String type fields";
 const MSG_REGEX_ONLY_FOR_STRING: &str = "Regex operators only supports string operands";
-const MSG_PREFFIX_POSTFIX_ONLY_FOR_STRING: &str =
+const MSG_PREFIX_POSTFIX_ONLY_FOR_STRING: &str =
     "Prefix/Postfix operators only supports string operands";
 const MSG_ONLY_FOR_INT: &str =
     "Greater/GreaterOrEqual/Less/LessOrEqual operators only supports integer operands";
@@ -130,7 +130,7 @@ impl Validate for Expression {
                     }
                     Prefix | Postfix => match p.rhs {
                         Value::String(_) => Ok(()),
-                        _ => raise_err(MSG_PREFFIX_POSTFIX_ONLY_FOR_STRING),
+                        _ => raise_err(MSG_PREFIX_POSTFIX_ONLY_FOR_STRING),
                     },
                     Greater | GreaterOrEqual | Less | LessOrEqual => match p.rhs {
                         Value::Int(_) => Ok(()),

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -97,11 +97,6 @@ impl Validate for Expression {
                 Ok(())
             }
             Predicate(p) => {
-                use BinaryOperator::{
-                    Contains, Equals, Greater, GreaterOrEqual, In, Less, LessOrEqual, NotEquals,
-                    NotIn, Postfix, Prefix, Regex,
-                };
-
                 // lhs and rhs must be the same type
                 let Some(lhs_type) = p.lhs.my_type(schema) else {
                     return raise_err(MSG_UNKNOWN_LHS);
@@ -121,6 +116,11 @@ impl Validate for Expression {
                 if lower && lhs_type != &Type::String {
                     return raise_err(MSG_LOWER_ONLY_FOR_STRING);
                 }
+
+                use BinaryOperator::{
+                    Contains, Equals, Greater, GreaterOrEqual, In, Less, LessOrEqual, NotEquals,
+                    NotIn, Postfix, Prefix, Regex,
+                };
 
                 match p.op {
                     Equals | NotEquals => Ok(()),

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -3,18 +3,19 @@ use crate::schema::Schema;
 use std::collections::HashMap;
 
 type ValidationResult = Result<(), String>;
+type ValidationHashMap = HashMap<String, usize>;
 
 pub trait Validate {
     fn validate(&self, schema: &Schema) -> ValidationResult;
 }
 
 pub trait FieldCounter {
-    fn add_to_counter(&self, map: &mut HashMap<String, usize>);
-    fn remove_from_counter(&self, map: &mut HashMap<String, usize>);
+    fn add_to_counter(&self, map: &mut ValidationHashMap);
+    fn remove_from_counter(&self, map: &mut ValidationHashMap);
 }
 
 impl FieldCounter for Expression {
-    fn add_to_counter(&self, map: &mut HashMap<String, usize>) {
+    fn add_to_counter(&self, map: &mut ValidationHashMap) {
         use Expression::*;
         use LogicalExpression::*;
 
@@ -34,7 +35,7 @@ impl FieldCounter for Expression {
         }
     }
 
-    fn remove_from_counter(&self, map: &mut HashMap<String, usize>) {
+    fn remove_from_counter(&self, map: &mut ValidationHashMap) {
         use Expression::*;
         use LogicalExpression::*;
 


### PR DESCRIPTION
[KAG-7221](https://konghq.atlassian.net/browse/KAG-7221) 
Code clean:
- const string for err message
- `raise_err()` to simplify error handling
- `use` in funtions

[KAG-7221]: https://konghq.atlassian.net/browse/KAG-7221?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ