### PR TITLE
refactor(src): add `reset()` for Match

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -18,6 +18,11 @@ impl Match {
             captures: FnvHashMap::default(),
         }
     }
+
+    pub fn reset(&mut self) {
+        self.matches.clear();
+        self.captures.clear();
+    }
 }
 
 impl Default for Match {

--- a/src/context.rs
+++ b/src/context.rs
@@ -19,7 +19,7 @@ impl Match {
         }
     }
 
-    pub fn reset(&mut self) {
+    pub(crate) fn reset(&mut self) {
         self.matches.clear();
         self.captures.clear();
     }

--- a/src/router.rs
+++ b/src/router.rs
@@ -75,12 +75,15 @@ impl<'a> Router<'a> {
     /// Note that unlike `execute`, this doesn't set `Context.result`
     /// but it also doesn't need a `&mut Context`.
     pub fn try_match(&self, context: &Context) -> Option<Match> {
+        let mut mat = Match::new();
+
         for (MatcherKey(_, id), m) in self.matchers.iter().rev() {
-            let mut mat = Match::new();
             if m.execute(context, &mut mat) {
                 mat.uuid = *id;
                 return Some(mat);
             }
+
+            mat.reset();
         }
 
         None


### PR DESCRIPTION
https://konghq.atlassian.net/browse/KAG-7221

It may improve the performance of `try_match()` a little.
In `m.execute()`, `mat` may allocate memory in hashmap, the PR could reuse these memory to avoid re-allocating.