### PR TITLE
feat(*): schema owned or referenced

### DIFF
--- a/src/ffi/context.rs
+++ b/src/ffi/context.rs
@@ -19,6 +19,8 @@ use uuid::fmt::Hyphenated;
 /// Violating any of the following constraints will result in undefined behavior:
 ///
 /// - `schema` must be a valid pointer returned by [`schema_new`].
+///
+/// [`schema_new`]: crate::ffi::schema::schema_new
 #[no_mangle]
 pub unsafe extern "C" fn context_new(schema: &Schema) -> *mut Context {
     Box::into_raw(Box::new(Context::new(schema)))
@@ -181,6 +183,8 @@ pub unsafe extern "C" fn context_reset(context: &mut Context) {
 ///
 /// Note: You should get the `<captures>` by calling this function and set every pointer
 /// except the `context` to `NULL` to get the number of captures.
+///
+/// [`router_execute`]: crate::ffi::router::router_execute
 #[no_mangle]
 pub unsafe extern "C" fn context_get_result(
     context: &Context,

--- a/src/ffi/expression.rs
+++ b/src/ffi/expression.rs
@@ -143,6 +143,8 @@ pub const ATC_ROUTER_EXPRESSION_VALIDATE_BUF_TOO_SMALL: i64 = 2;
 /// - `operators` must be a valid pointer to write `size_of::<u64>()` bytes and properly aligned.
 /// - `errbuf` must be valid for reading and writing `errbuf_len * size_of::<u8>()` bytes and properly aligned.
 /// - `errbuf_len` must be a valid pointer for reading and writing `size_of::<usize>()` bytes and properly aligned.
+///
+/// [`schema_new`]: crate::ffi::schema::schema_new
 #[no_mangle]
 pub unsafe extern "C" fn expression_validate(
     atc: *const u8,

--- a/src/ffi/router.rs
+++ b/src/ffi/router.rs
@@ -23,6 +23,8 @@ use uuid::Uuid;
 /// Violating any of the following constraints will result in undefined behavior:
 ///
 /// - `schema` must be a valid pointer returned by [`schema_new`].
+///
+/// [`schema_new`]: crate::ffi::schema::schema_new
 #[no_mangle]
 pub unsafe extern "C" fn router_new(schema: &Schema) -> *mut Router {
     Box::into_raw(Box::new(Router::new(schema)))
@@ -167,6 +169,9 @@ pub unsafe extern "C" fn router_remove_matcher(
 /// - `context` must be a valid pointer returned by [`context_new`],
 ///   and must be reset by [`context_reset`] before calling this function
 ///   if you want to reuse the same context for multiple matches.
+///
+/// [`context_new`]: crate::ffi::context::context_new
+/// [`context_reset`]: crate::ffi::context::context_reset
 #[no_mangle]
 pub unsafe extern "C" fn router_execute(router: &Router, context: &mut Context) -> bool {
     router.execute(context)

--- a/src/router.rs
+++ b/src/router.rs
@@ -5,6 +5,7 @@ use crate::parser::parse;
 use crate::schema::Schema;
 use crate::semantics::{FieldCounter, Validate};
 use std::collections::{BTreeMap, HashMap};
+use std::ops::Deref;
 use uuid::Uuid;
 
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
@@ -12,18 +13,44 @@ struct MatcherKey(usize, Uuid);
 
 #[derive(Debug)]
 pub struct Router<'a> {
-    schema: &'a Schema,
+    schema: SchemaOwnedOrRef<'a>,
     matchers: BTreeMap<MatcherKey, Expression>,
     pub fields: HashMap<String, usize>,
 }
 
 impl<'a> Router<'a> {
+    /// Creates a new [`Router`] that holds a shared reference to a [`Schema`].
+    ///
+    /// This is useful when the schema is managed outside the router and/or shared
+    /// across multiple components.
     pub fn new(schema: &'a Schema) -> Self {
         Self {
-            schema,
+            schema: SchemaOwnedOrRef::Ref(schema),
             matchers: BTreeMap::new(),
             fields: HashMap::new(),
         }
+    }
+
+    /// Creates a new [`Router`] that owns its [`Schema`].
+    ///
+    /// This allows the router to be self contained,
+    /// making it easier to use as a standalone component.
+    pub fn new_owning(schema: Schema) -> Self {
+        Self {
+            schema: SchemaOwnedOrRef::Owned(schema),
+            matchers: BTreeMap::new(),
+            fields: HashMap::new(),
+        }
+    }
+
+    /// Returns a reference to the [`Schema`] used by this router.
+    ///
+    /// Especially useful if the router owns the schema internally ([`new_owning`]),
+    /// but you still need to pass a reference to other components like [`Context`].
+    ///
+    /// [`new_owning`]: Router::new_owning
+    pub fn schema(&self) -> &Schema {
+        &self.schema
     }
 
     pub fn add_matcher(&mut self, priority: usize, uuid: Uuid, atc: &str) -> Result<(), String> {
@@ -44,7 +71,7 @@ impl<'a> Router<'a> {
             return Err("UUID already exists".to_string());
         }
 
-        expr.validate(self.schema)?;
+        expr.validate(&self.schema)?;
         expr.add_to_counter(&mut self.fields);
 
         assert!(self.matchers.insert(key, expr).is_none());
@@ -84,6 +111,30 @@ impl<'a> Router<'a> {
         }
 
         None
+    }
+}
+
+/// A smart pointer over a [`Schema`], which may be either borrowed or owned.
+///
+/// Used by [`Router`] to support both externally managed and self-contained schemas.
+/// Owning the schema is especially useful when the router is used outside of the FFI context,
+/// making it fully independent.
+///
+/// Implements [`Deref`] for ergonomic access to the underlying [`Schema`].
+#[derive(Debug)]
+enum SchemaOwnedOrRef<'a> {
+    Ref(&'a Schema),
+    Owned(Schema),
+}
+
+impl Deref for SchemaOwnedOrRef<'_> {
+    type Target = Schema;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Ref(s) => s,
+            Self::Owned(s) => s,
+        }
     }
 }
 
@@ -153,5 +204,19 @@ mod tests {
         let mut ctx = Context::new(&schema);
         ctx.add_value("http.path", "/not-dev".to_owned().into());
         router.try_match(&ctx).ok_or(()).expect_err("should fail");
+    }
+
+    #[test]
+    fn test_basic_owned_schema() {
+        let mut schema = Schema::default();
+        schema.add_field("http.path", Type::String);
+
+        let mut router: Router<'static> = Router::new_owning(schema);
+        router
+            .add_matcher(0, Uuid::default(), "http.path == \"/dev\"")
+            .expect("should add");
+        let mut ctx = Context::new(router.schema());
+        ctx.add_value("http.path", "/dev".to_owned().into());
+        router.try_match(&ctx).expect("matches");
     }
 }


### PR DESCRIPTION
This PR introduces a new way of initializing ATC so that it *owns* the schema that it depends on, instead of relying on a shared reference.

This facilitates the workflow especially when ATC is instantiated and used in Rust libraries, particularly in use cases where it needs to be cached for reuse - so that it is not necessary to maintain a reference to an external Schema object.

This is based on @lucab 's [work](https://github.com/lucab/atc-router/pull/1/files) and includes some small changes that are a follow up to his observations (same PR).

HOUD-98