### PR TITLE
chore: fix clippy::uninlined_format_args error

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -253,7 +253,7 @@ fn parse_transform_func(pair: Pair<Rule>) -> ParseResult<Lhs> {
         unknown => {
             return Err(ParseError::new_from_span(
                 ErrorVariant::CustomError {
-                    message: format!("unknown transformation function: {}", unknown),
+                    message: format!("unknown transformation function: {unknown}"),
                 },
                 span,
             ));


### PR DESCRIPTION
I've opened https://github.com/Kong/public-shared-actions/issues/268 for this but the action we're using uses the deprecated `actions-rs/toolchain` and also doesn't allow pinning the rust version so this started failing when 1.88 was released