### PR TITLE
feat: bool value

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 
 t/servroot
 Cargo.lock
+
+.idea/

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -52,6 +52,7 @@ pub enum Value {
     IpCidr(IpCidr),
     IpAddr(IpAddr),
     Int(i64),
+    Bool(bool),
     #[cfg_attr(feature = "serde", serde(with = "serde_regex"))]
     Regex(Regex),
 }
@@ -66,6 +67,7 @@ impl PartialEq for Value {
             (Self::IpCidr(i1), Self::IpCidr(i2)) => i1 == i2,
             (Self::IpAddr(i1), Self::IpAddr(i2)) => i1 == i2,
             (Self::Int(i1), Self::Int(i2)) => i1 == i2,
+            (Self::Bool(b1), Self::Bool(b2)) => b1 == b2,
             _ => false,
         }
     }
@@ -80,6 +82,7 @@ impl Value {
             Value::IpCidr(_) => Type::IpCidr,
             Value::IpAddr(_) => Type::IpAddr,
             Value::Int(_) => Type::Int,
+            Value::Bool(_) => Type::Bool,
             Value::Regex(_) => Type::Regex,
         }
     }
@@ -105,6 +108,13 @@ impl Value {
             return None;
         };
         Some(*i)
+    }
+
+    pub fn as_bool(&self) -> Option<bool> {
+        let Value::Bool(b) = self else {
+            return None;
+        };
+        Some(*b)
     }
 
     pub fn as_ipaddr(&self) -> Option<&IpAddr> {
@@ -136,6 +146,7 @@ pub enum Type {
     IpCidr,
     IpAddr,
     Int,
+    Bool,
     Regex,
 }
 
@@ -231,6 +242,7 @@ mod tests {
                 Value::IpCidr(cidr) => write!(f, "{}", cidr),
                 Value::IpAddr(addr) => write!(f, "{}", addr),
                 Value::Int(i) => write!(f, "{}", i),
+                Value::Bool(b) => write!(f, "{}", b),
                 Value::Regex(re) => write!(f, "\"{}\"", re),
             }
         }

--- a/src/atc_grammar.pest
+++ b/src/atc_grammar.pest
@@ -1,6 +1,6 @@
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
 ident = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_" | ".")* }
-rhs = { str_literal | rawstr_literal | ip_literal | int_literal }
+rhs = { str_literal | rawstr_literal | ip_literal | int_literal | bool_literal }
 transform_func = { ident ~ "(" ~ lhs ~ ")" }
 lhs = { transform_func | ident }
 
@@ -11,6 +11,7 @@ hex_digits = { ASCII_HEX_DIGIT+ }
 oct_digits = { "0" ~ ASCII_OCT_DIGIT+ }
 dec_digits = { ASCII_DIGIT+ }
 
+bool_literal = ${ "true" | "false" }
 
 str_literal = ${ "\"" ~ str_inner ~ "\"" }
 str_inner = _{ (str_esc | str_char)* }

--- a/src/ffi/context.rs
+++ b/src/ffi/context.rs
@@ -22,7 +22,7 @@ use uuid::fmt::Hyphenated;
 ///
 /// [`schema_new`]: crate::ffi::schema::schema_new
 #[no_mangle]
-pub unsafe extern "C" fn context_new(schema: &Schema) -> *mut Context {
+pub unsafe extern "C" fn context_new(schema: &Schema) -> *mut Context<'_> {
     Box::into_raw(Box::new(Context::new(schema)))
 }
 

--- a/src/ffi/expression.rs
+++ b/src/ffi/expression.rs
@@ -42,7 +42,7 @@ impl<'a> Iterator for PredicateIterator<'a> {
 }
 
 impl Expression {
-    fn iter_predicates(&self) -> PredicateIterator {
+    fn iter_predicates(&self) -> PredicateIterator<'_> {
         PredicateIterator::new(self)
     }
 }

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -20,6 +20,7 @@ pub enum CValue {
     IpCidr(*const u8),
     IpAddr(*const u8),
     Int(i64),
+    Bool(bool),
 }
 
 impl TryFrom<&CValue> for Value {
@@ -53,6 +54,7 @@ impl TryFrom<&CValue> for Value {
                 .map_err(|e| e.to_string())?,
             ),
             CValue::Int(i) => Self::Int(*i),
+            CValue::Bool(b) => Self::Bool(*b),
         })
     }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -95,7 +95,7 @@ fn parse_lhs(pair: Pair<Rule>) -> ParseResult<Lhs> {
     })
 }
 
-// rhs = { str_literal | ip_literal | int_literal }
+// rhs = { str_literal | rawstr_literal | ip_literal | int_literal | bool_literal }
 #[allow(clippy::result_large_err)] // it's fine as parsing is not the hot path
 fn parse_rhs(pair: Pair<Rule>) -> ParseResult<Value> {
     let pairs = pair.into_inner();
@@ -109,6 +109,7 @@ fn parse_rhs(pair: Pair<Rule>) -> ParseResult<Value> {
         Rule::ipv4_literal => Value::IpAddr(IpAddr::V4(parse_ipv4_literal(pair)?)),
         Rule::ipv6_literal => Value::IpAddr(IpAddr::V6(parse_ipv6_literal(pair)?)),
         Rule::int_literal => Value::Int(parse_int_literal(pair)?),
+        Rule::bool_literal => Value::Bool(parse_bool_literal(pair)?),
         _ => unreachable!(),
     })
 }
@@ -200,6 +201,15 @@ fn parse_int_literal(pair: Pair<Rule>) -> ParseResult<i64> {
     }
 
     Ok(num)
+}
+
+#[allow(clippy::result_large_err)] // it's fine as parsing is not the hot path
+fn parse_bool_literal(pair: Pair<Rule>) -> ParseResult<bool> {
+    match pair.as_str() {
+        "true" => Ok(true),
+        "false" => Ok(false),
+        _ => unreachable!(),
+    }
 }
 
 // predicate = { lhs ~ binary_operator ~ rhs }

--- a/src/router.rs
+++ b/src/router.rs
@@ -114,6 +114,7 @@ mod tests {
     use super::Router;
 
     use std::sync::Arc;
+    use crate::ast::Value;
 
     #[test]
     fn execute_succeeds() {
@@ -228,6 +229,21 @@ mod tests {
             .expect("should add");
         let mut ctx = Context::new(router.schema());
         ctx.add_value("http.path", "/dev".to_owned().into());
+        router.try_match(&ctx).expect("matches");
+    }
+
+    #[test]
+    fn test_bool() {
+        let mut schema = Schema::default();
+        schema.add_field("kafka.record.value.validated", Type::Bool);
+
+        let mut router = Router::new(&schema);
+        router
+            .add_matcher(0, Uuid::default(), "kafka.record.value.validated == true")
+            .expect("should add");
+
+        let mut ctx = Context::new(&schema);
+        ctx.add_value("kafka.record.value.validated", Value::Bool(true));
         router.try_match(&ctx).expect("matches");
     }
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -32,12 +32,14 @@ mod tests {
         s.add_field("cidr", Type::IpCidr);
         s.add_field("r", Type::Regex);
         s.add_field("i", Type::Int);
+        s.add_field("b", Type::Bool);
 
         assert_eq!(s.type_of("str"), Some(&Type::String));
         assert_eq!(s.type_of("ip"), Some(&Type::IpAddr));
         assert_eq!(s.type_of("cidr"), Some(&Type::IpCidr));
         assert_eq!(s.type_of("r"), Some(&Type::Regex));
         assert_eq!(s.type_of("i"), Some(&Type::Int));
+        assert_eq!(s.type_of("b"), Some(&Type::Bool));
 
         assert_eq!(s.type_of("unknown"), None);
     }


### PR DESCRIPTION
This PR adds a bool value type to ATC. It's not clear to me what to do with `lib/resty/router` files. It says it's autogenerated, but there are no docs really on what's required and how it works. Just running `cbindgen -l c` as comment says outputs for me quite a different file. I could use some help 🙏 

Fix #325