### PR TITLE
fix(lint): mismatched lifetime syntaxes due to newer rust toolchain

### DIFF
--- a/src/ffi/context.rs
+++ b/src/ffi/context.rs
@@ -22,7 +22,7 @@ use uuid::fmt::Hyphenated;
 ///
 /// [`schema_new`]: crate::ffi::schema::schema_new
 #[no_mangle]
-pub unsafe extern "C" fn context_new(schema: &Schema) -> *mut Context {
+pub unsafe extern "C" fn context_new(schema: &Schema) -> *mut Context<'_> {
     Box::into_raw(Box::new(Context::new(schema)))
 }
 

--- a/src/ffi/expression.rs
+++ b/src/ffi/expression.rs
@@ -42,7 +42,7 @@ impl<'a> Iterator for PredicateIterator<'a> {
 }
 
 impl Expression {
-    fn iter_predicates(&self) -> PredicateIterator {
+    fn iter_predicates(&self) -> PredicateIterator<'_> {
         PredicateIterator::new(self)
     }
 }


### PR DESCRIPTION
We should pin the Rust version eventually.
Ref: https://blog.rust-lang.org/2025/08/07/Rust-1.89.0/#mismatched-lifetime-syntaxes-lint