### PR TITLE
feat(ffi): improve error buffer writing more

### DIFF
--- a/src/ffi/context.rs
+++ b/src/ffi/context.rs
@@ -75,9 +75,8 @@ pub unsafe extern "C" fn context_free(context: *mut Context) {
 /// * `field` must be a valid pointer to a C-style string,
 ///   must be properply aligned, and must not have '\0' in the middle.
 /// * `value` must be a valid pointer to a [`CValue`].
-/// * `errbuf` must be valid to read and write for `errbuf_len * size_of::<u8>()` bytes,
-///   and it must be properly aligned.
-/// * `errbuf_len` must be vlaid to read and write for `size_of::<usize>()` bytes,
+/// * `errbuf` must be valid to read and write for `*errbuf_len` bytes.
+/// * `errbuf_len` must be valid to read and write for `size_of::<usize>()` bytes,
 ///   and it must be properly aligned.
 #[no_mangle]
 pub unsafe extern "C" fn context_add_value(
@@ -85,7 +84,7 @@ pub unsafe extern "C" fn context_add_value(
     field: *const i8,
     value: &CValue,
     errbuf: *mut u8,
-    errbuf_len: *mut usize,
+    errbuf_len: &mut usize,
 ) -> bool {
     let field = ffi::CStr::from_ptr(field as *const c_char)
         .to_str()

--- a/src/ffi/context.rs
+++ b/src/ffi/context.rs
@@ -21,7 +21,7 @@ use uuid::fmt::Hyphenated;
 ///
 /// [`schema_new`]: crate::ffi::schema::schema_new
 #[no_mangle]
-pub unsafe extern "C" fn context_new(schema: &Schema) -> *mut Context {
+pub unsafe extern "C" fn context_new(schema: &Schema) -> *mut Context<'_> {
     Box::into_raw(Box::new(Context::new(schema)))
 }
 

--- a/src/ffi/context.rs
+++ b/src/ffi/context.rs
@@ -158,9 +158,9 @@ pub unsafe extern "C" fn context_reset(context: &mut Context) {
 ///   must be passed to [`router_execute`] before calling this function,
 ///   and must not be reset by [`context_reset`] before calling this function.
 /// - If `uuid_hex` is not `NULL`, `uuid_hex` must be valid to read and write for
-///   `16 * size_of::<u8>()` bytes, and it must be properly aligned.
+///   `36` bytes.
 /// - If `matched_field` is not `NULL`,
-///   `matched_field` must be a vlaid pointer to a C-style string,
+///   `matched_field` must be a valid pointer to a C-style string,
 ///   must be properly aligned, and must not have '\0' in the middle.
 /// - If `matched_value` is not `NULL`,
 ///   `matched_value` must be valid to read and write for

--- a/src/ffi/expression.rs
+++ b/src/ffi/expression.rs
@@ -41,7 +41,7 @@ impl<'a> Iterator for PredicateIterator<'a> {
 }
 
 impl Expression {
-    fn iter_predicates(&self) -> PredicateIterator {
+    fn iter_predicates(&self) -> PredicateIterator<'_> {
         PredicateIterator::new(self)
     }
 }

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -5,7 +5,6 @@ pub mod schema;
 
 use crate::ast::Value;
 use cidr::IpCidr;
-use std::cmp::min;
 use std::convert::TryFrom;
 use std::ffi;
 use std::fmt::Display;
@@ -14,6 +13,10 @@ use std::os::raw::c_char;
 use std::slice::from_raw_parts;
 use std::slice::from_raw_parts_mut;
 
+/// A _suggestion_ of the value to use for `errbuf_len`
+///
+/// This value is actually not used for anything in this library,
+/// any length can be passed.
 pub const ERR_BUF_MAX_LEN: usize = 4096;
 
 #[derive(Debug)]
@@ -72,18 +75,14 @@ impl TryFrom<&CValue> for Value {
 ///
 /// Violating any of the following constraints will result in undefined behavior:
 ///
-/// * `errbuf` must be valid to read and write for `errbuf_len * size_of::<u8>()` bytes,
-///   and it must be properly aligned.
-/// * `errbuf_len` must be vlaid to read and write for `size_of::<usize>()` bytes,
-///   and it must be properly aligned.
-unsafe fn write_errbuf(err: impl Display, errbuf: *mut u8, errbuf_len: *mut usize) {
-    let errbuf = from_raw_parts_mut(errbuf, ERR_BUF_MAX_LEN);
-    // Replace internal '\0' to space.
-    let err = err.to_string().replace('\0', " ");
-    // Unwrap is safe since we already remove all internal '\0's.
-    let err_cstring = std::ffi::CString::new(err.to_string()).unwrap();
-    let err_bytes = err_cstring.as_bytes_with_nul();
-    let errlen = min(err_bytes.len(), *errbuf_len);
-    errbuf[..errlen].copy_from_slice(&err_bytes[..errlen]);
-    *errbuf_len = errlen;
+/// * `errbuf` must be valid to read and write for `*errbuf_len` bytes.
+unsafe fn write_errbuf(err: impl Display, errbuf: *mut u8, errbuf_len: &mut usize) {
+    use std::io::Write;
+
+    let orig_len = *errbuf_len;
+    let mut errbuf = from_raw_parts_mut(errbuf, orig_len);
+    // Ignore truncation error
+    let _ = write!(errbuf, "{}", err);
+    let remaining_len = errbuf.len();
+    *errbuf_len = orig_len - remaining_len;
 }

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -5,11 +5,14 @@ pub mod schema;
 
 use crate::ast::Value;
 use cidr::IpCidr;
+use std::cmp::min;
 use std::convert::TryFrom;
 use std::ffi;
+use std::fmt::Display;
 use std::net::IpAddr;
 use std::os::raw::c_char;
 use std::slice::from_raw_parts;
+use std::slice::from_raw_parts_mut;
 
 pub const ERR_BUF_MAX_LEN: usize = 4096;
 
@@ -55,4 +58,32 @@ impl TryFrom<&CValue> for Value {
             CValue::Int(i) => Self::Int(*i),
         })
     }
+}
+
+/// Write displayable error message to the error buffer.
+///
+/// # Arguments
+///
+/// - `err`: the displayable error message.
+/// - `errbuf`: a buffer to store the error message.
+/// - `errbuf_len`: a pointer to the length of the error message buffer.
+///
+/// # Safety
+///
+/// Violating any of the following constraints will result in undefined behavior:
+///
+/// * `errbuf` must be valid to read and write for `errbuf_len * size_of::<u8>()` bytes,
+///   and it must be properly aligned.
+/// * `errbuf_len` must be vlaid to read and write for `size_of::<usize>()` bytes,
+///   and it must be properly aligned.
+unsafe fn write_errbuf(err: impl Display, errbuf: *mut u8, errbuf_len: *mut usize) {
+    let errbuf = from_raw_parts_mut(errbuf, ERR_BUF_MAX_LEN);
+    // Replace internal '\0' to space.
+    let err = err.to_string().replace('\0', " ");
+    // Unwrap is safe since we already remove all internal '\0's.
+    let err_cstring = std::ffi::CString::new(err.to_string()).unwrap();
+    let err_bytes = err_cstring.as_bytes_with_nul();
+    let errlen = min(err_bytes.len(), *errbuf_len);
+    errbuf[..errlen].copy_from_slice(&err_bytes[..errlen]);
+    *errbuf_len = errlen;
 }

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -17,6 +17,7 @@ use std::slice::from_raw_parts_mut;
 ///
 /// This value is actually not used for anything in this library,
 /// any length can be passed.
+#[deprecated]
 pub const ERR_BUF_MAX_LEN: usize = 4096;
 
 #[derive(Debug)]

--- a/src/ffi/router.rs
+++ b/src/ffi/router.rs
@@ -84,8 +84,7 @@ pub unsafe extern "C" fn router_free(router: *mut Router<&Schema>) {
 ///   and must not have '\0' in the middle.
 /// - `atc` must be a valid pointer to a C-style string, must be properly aligned,
 ///   and must not have '\0' in the middle.
-/// - `errbuf` must be valid to read and write for `errbuf_len * size_of::<u8>()` bytes,
-///   and it must be properly aligned.
+/// - `errbuf` must be valid to read and write for `*errbuf_len` bytes.
 /// - `errbuf_len` must be valid to read and write for `size_of::<usize>()` bytes,
 ///   and it must be properly aligned.
 #[no_mangle]
@@ -95,7 +94,7 @@ pub unsafe extern "C" fn router_add_matcher(
     uuid: *const i8,
     atc: *const i8,
     errbuf: *mut u8,
-    errbuf_len: *mut usize,
+    errbuf_len: &mut usize,
 ) -> bool {
     let uuid = ffi::CStr::from_ptr(uuid as *const c_char).to_str().unwrap();
     let atc = ffi::CStr::from_ptr(atc as *const c_char).to_str().unwrap();
@@ -241,6 +240,30 @@ pub unsafe extern "C" fn router_get_fields(
 mod tests {
     use super::*;
     use crate::ffi::ERR_BUF_MAX_LEN;
+
+    #[test]
+    fn test_short_error_buf() {
+        unsafe {
+            let schema = Schema::default();
+            let mut router = Router::new(&schema);
+            let uuid = ffi::CString::new("a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c").unwrap();
+            let junk = ffi::CString::new(vec![b'a'; ERR_BUF_MAX_LEN * 2]).unwrap();
+            let mut errbuf = vec![b'X'; ERR_BUF_MAX_LEN];
+            let mut errbuf_len = 10;
+
+            let result = router_add_matcher(
+                &mut router,
+                1,
+                uuid.as_ptr() as *const i8,
+                junk.as_ptr() as *const i8,
+                errbuf[..errbuf_len].as_mut_ptr(),
+                &mut errbuf_len,
+            );
+            assert!(!result);
+            assert_eq!(errbuf_len, 10);
+            assert_eq!(errbuf[10], b'X');
+        }
+    }
 
     #[test]
     fn test_long_error_message() {


### PR DESCRIPTION
Builds on #276, but adds some improvements:

- No longer silently truncate to `ERR_BUF_MAX_LEN`, errors can now be any size the caller specifies
- Fixes a regression, there's no need for the error to be null terminated, and the value stored at `*errbuf_len` again matches the length of the actual error text, not the text plus a null terminator
- Runs safely under `miri`

Closes #276