### PR TITLE
style: remove legacy extern crate declarations

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,3 @@ pub mod semantics;
 
 #[cfg(feature = "ffi")]
 pub mod ffi;
-
-#[macro_use]
-extern crate pest_derive;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,5 +1,3 @@
-extern crate pest;
-
 use crate::ast::{
     BinaryOperator, Expression, Lhs, LhsTransformations, LogicalExpression, Predicate, Value,
 };
@@ -10,6 +8,7 @@ use pest::iterators::Pair;
 use pest::pratt_parser::Assoc as AssocNew;
 use pest::pratt_parser::{Op, PrattParser};
 use pest::Parser;
+use pest_derive::Parser;
 use regex::Regex;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 


### PR DESCRIPTION
After rust edition 2018, `use` statements can import procedural macro
https://doc.rust-lang.org/book/ch20-05-macros.html