### PR TITLE
Add nil check POC

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Each data referred in the DSL has a type, the type can be one of the following:
 * `IpAddr` - a single IP address that can be checked against an `IpCidr`
 * `Int` - an 64-bit signed integer
 
+`nil` is not a schema type. In expressions, `field == nil` and `field != nil`
+can be used to test whether a schema-known field is missing from, or present in,
+the runtime context.
+
 Please refer to the [documentation](https://docs.konghq.com/gateway/latest/reference/expressions-language/)
 on Kong website for how the language is used in practice.
 
@@ -271,4 +275,3 @@ Licensed under the [Apache License, Version 2.0](https://www.apache.org/licenses
 Files in the project may not be copied, modified, or distributed except according to those terms.
 
 [Back to TOC](#table-of-contents)
-

--- a/src/ast.rs
+++ b/src/ast.rs
@@ -166,9 +166,16 @@ impl Lhs {
 
 #[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
 #[derive(Clone, Debug, PartialEq, Eq)]
+pub enum PredicateRhs {
+    Value(Value),
+    Missing,
+}
+
+#[cfg_attr(feature = "serde", derive(Serialize, Deserialize))]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Predicate {
     pub lhs: Lhs,
-    pub rhs: Value,
+    pub rhs: PredicateRhs,
     pub op: BinaryOperator,
 }
 
@@ -232,6 +239,15 @@ mod tests {
                 Value::IpAddr(addr) => write!(f, "{}", addr),
                 Value::Int(i) => write!(f, "{}", i),
                 Value::Regex(re) => write!(f, "\"{}\"", re),
+            }
+        }
+    }
+
+    impl fmt::Display for PredicateRhs {
+        fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+            match self {
+                PredicateRhs::Value(value) => write!(f, "{}", value),
+                PredicateRhs::Missing => write!(f, "nil"),
             }
         }
     }
@@ -308,6 +324,7 @@ mod tests {
                 "!(a == 1 || b == 2 && c == 3) && d == 4",
                 "(!((((a == 1) || (b == 2)) && (c == 3))) && (d == 4))",
             ),
+            ("a == nil || b != nil", "((a == nil) || (b != nil))"),
         ];
         for (input, expected) in tests {
             let result = parse(input).unwrap();

--- a/src/atc_grammar.pest
+++ b/src/atc_grammar.pest
@@ -1,6 +1,6 @@
 WHITESPACE = _{ " " | "\t" | "\r" | "\n" }
 ident = @{ ASCII_ALPHA ~ (ASCII_ALPHANUMERIC | "_" | ".")* }
-rhs = { str_literal | rawstr_literal | ip_literal | int_literal }
+rhs = { str_literal | rawstr_literal | ip_literal | int_literal | nil_literal }
 transform_func = { ident ~ "(" ~ lhs ~ ")" }
 lhs = { transform_func | ident }
 
@@ -19,6 +19,7 @@ str_esc = { "\\" ~ ("\"" | "\\" | "n" | "r" | "t") }
 
 rawstr_literal = ${ "r#\"" ~ rawstr_char* ~ "\"#" }
 rawstr_char = { !"\"#" ~ ANY }
+nil_literal = { "nil" }
 
 ipv4_literal = @{ ASCII_DIGIT{1,3} ~ ( "." ~ ASCII_DIGIT{1,3} ){3} }
 ipv6_literal = @{

--- a/src/interpreter.rs
+++ b/src/interpreter.rs
@@ -1,4 +1,4 @@
-use crate::ast::{BinaryOperator, Expression, LogicalExpression, Predicate, Value};
+use crate::ast::{BinaryOperator, Expression, LogicalExpression, Predicate, PredicateRhs, Value};
 use crate::context::{Context, Match};
 
 pub trait Execute {
@@ -20,9 +20,23 @@ impl Execute for Expression {
 
 impl Execute for Predicate {
     fn execute(&self, ctx: &Context, m: &mut Match) -> bool {
+        if matches!(self.rhs, PredicateRhs::Missing) {
+            let present = ctx.value_of(&self.lhs.var_name).is_some();
+
+            return match self.op {
+                BinaryOperator::Equals => !present,
+                BinaryOperator::NotEquals => present,
+                _ => false,
+            };
+        }
+
         let lhs_values = match ctx.value_of(&self.lhs.var_name) {
             None => return false,
             Some(v) => v,
+        };
+
+        let PredicateRhs::Value(rhs) = &self.rhs else {
+            unreachable!();
         };
 
         let (lower, any) = self.lhs.get_transformations();
@@ -46,9 +60,8 @@ impl Execute for Predicate {
             let mut matched = false;
             match self.op {
                 BinaryOperator::Equals => {
-                    if lhs_value == &self.rhs {
-                        m.matches
-                            .insert(self.lhs.var_name.clone(), self.rhs.clone());
+                    if lhs_value == rhs {
+                        m.matches.insert(self.lhs.var_name.clone(), rhs.clone());
 
                         if any {
                             return true;
@@ -58,7 +71,7 @@ impl Execute for Predicate {
                     }
                 }
                 BinaryOperator::NotEquals => {
-                    if lhs_value != &self.rhs {
+                    if lhs_value != rhs {
                         if any {
                             return true;
                         }
@@ -71,7 +84,7 @@ impl Execute for Predicate {
                     // the semantic checking didn't catch the mismatched types,
                     // which is a bug.
                     let lhs = lhs_value.as_str().unwrap();
-                    let rhs = self.rhs.as_regex().unwrap();
+                    let rhs = rhs.as_regex().unwrap();
 
                     if rhs.is_match(lhs) {
                         let reg_cap = rhs.captures(lhs).unwrap();
@@ -106,11 +119,11 @@ impl Execute for Predicate {
                     // the semantic checking didn't catch the mismatched types,
                     // which is a bug.
                     let lhs = lhs_value.as_str().unwrap();
-                    let rhs = self.rhs.as_str().unwrap();
+                    let rhs = rhs.as_str().unwrap();
 
                     if lhs.starts_with(rhs) {
                         m.matches
-                            .insert(self.lhs.var_name.clone(), self.rhs.clone());
+                            .insert(self.lhs.var_name.clone(), rhs.to_string().into());
                         if any {
                             return true;
                         }
@@ -123,11 +136,11 @@ impl Execute for Predicate {
                     // the semantic checking didn't catch the mismatched types,
                     // which is a bug.
                     let lhs = lhs_value.as_str().unwrap();
-                    let rhs = self.rhs.as_str().unwrap();
+                    let rhs = rhs.as_str().unwrap();
 
                     if lhs.ends_with(rhs) {
                         m.matches
-                            .insert(self.lhs.var_name.clone(), self.rhs.clone());
+                            .insert(self.lhs.var_name.clone(), rhs.to_string().into());
                         if any {
                             return true;
                         }
@@ -140,7 +153,7 @@ impl Execute for Predicate {
                     // the semantic checking didn't catch the mismatched types,
                     // which is a bug.
                     let lhs = lhs_value.as_int().unwrap();
-                    let rhs = self.rhs.as_int().unwrap();
+                    let rhs = rhs.as_int().unwrap();
 
                     if lhs > rhs {
                         if any {
@@ -155,7 +168,7 @@ impl Execute for Predicate {
                     // the semantic checking didn't catch the mismatched types,
                     // which is a bug.
                     let lhs = lhs_value.as_int().unwrap();
-                    let rhs = self.rhs.as_int().unwrap();
+                    let rhs = rhs.as_int().unwrap();
 
                     if lhs >= rhs {
                         if any {
@@ -170,7 +183,7 @@ impl Execute for Predicate {
                     // the semantic checking didn't catch the mismatched types,
                     // which is a bug.
                     let lhs = lhs_value.as_int().unwrap();
-                    let rhs = self.rhs.as_int().unwrap();
+                    let rhs = rhs.as_int().unwrap();
 
                     if lhs < rhs {
                         if any {
@@ -185,7 +198,7 @@ impl Execute for Predicate {
                     // the semantic checking didn't catch the mismatched types,
                     // which is a bug.
                     let lhs = lhs_value.as_int().unwrap();
-                    let rhs = self.rhs.as_int().unwrap();
+                    let rhs = rhs.as_int().unwrap();
 
                     if lhs <= rhs {
                         if any {
@@ -200,7 +213,7 @@ impl Execute for Predicate {
                     // the semantic checking didn't catch the mismatched types,
                     // which is a bug.
                     let lhs = lhs_value.as_ipaddr().unwrap();
-                    let rhs = self.rhs.as_ipcidr().unwrap();
+                    let rhs = rhs.as_ipcidr().unwrap();
 
                     if rhs.contains(lhs) {
                         matched = true;
@@ -214,7 +227,7 @@ impl Execute for Predicate {
                     // the semantic checking didn't catch the mismatched types,
                     // which is a bug.
                     let lhs = lhs_value.as_ipaddr().unwrap();
-                    let rhs = self.rhs.as_ipcidr().unwrap();
+                    let rhs = rhs.as_ipcidr().unwrap();
 
                     if !rhs.contains(lhs) {
                         matched = true;
@@ -228,7 +241,7 @@ impl Execute for Predicate {
                     // the semantic checking didn't catch the mismatched types,
                     // which is a bug.
                     let lhs = lhs_value.as_str().unwrap();
-                    let rhs = self.rhs.as_str().unwrap();
+                    let rhs = rhs.as_str().unwrap();
 
                     if lhs.contains(rhs) {
                         if any {
@@ -270,7 +283,7 @@ fn test_predicate() {
             var_name: "my_key".to_string(),
             transformations: vec![],
         },
-        rhs: Value::String("foo".to_string()),
+        rhs: ast::PredicateRhs::Value(Value::String("foo".to_string())),
         op: BinaryOperator::Prefix,
     };
 
@@ -282,7 +295,7 @@ fn test_predicate() {
             var_name: "my_key".to_string(),
             transformations: vec![],
         },
-        rhs: Value::String("foo".to_string()),
+        rhs: ast::PredicateRhs::Value(Value::String("foo".to_string())),
         op: BinaryOperator::Prefix,
     };
 
@@ -306,7 +319,7 @@ fn test_predicate() {
             var_name: "my_key".to_string(),
             transformations: vec![],
         },
-        rhs: Value::String("foo".to_string()),
+        rhs: ast::PredicateRhs::Value(Value::String("foo".to_string())),
         op: BinaryOperator::Prefix,
     };
 
@@ -318,7 +331,7 @@ fn test_predicate() {
             var_name: "my_key".to_string(),
             transformations: vec![],
         },
-        rhs: Value::String("foo".to_string()),
+        rhs: ast::PredicateRhs::Value(Value::String("foo".to_string())),
         op: BinaryOperator::Postfix,
     };
 
@@ -330,7 +343,7 @@ fn test_predicate() {
             var_name: "my_key".to_string(),
             transformations: vec![ast::LhsTransformations::Any],
         },
-        rhs: Value::String("foo".to_string()),
+        rhs: ast::PredicateRhs::Value(Value::String("foo".to_string())),
         op: BinaryOperator::Postfix,
     };
 
@@ -342,7 +355,7 @@ fn test_predicate() {
             var_name: "my_key".to_string(),
             transformations: vec![ast::LhsTransformations::Any],
         },
-        rhs: Value::String("foo".to_string()),
+        rhs: ast::PredicateRhs::Value(Value::String("foo".to_string())),
         op: BinaryOperator::Prefix,
     };
 
@@ -354,7 +367,7 @@ fn test_predicate() {
             var_name: "my_key".to_string(),
             transformations: vec![ast::LhsTransformations::Any],
         },
-        rhs: Value::String("nar".to_string()),
+        rhs: ast::PredicateRhs::Value(Value::String("nar".to_string())),
         op: BinaryOperator::Postfix,
     };
 
@@ -366,7 +379,7 @@ fn test_predicate() {
             var_name: "my_key".to_string(),
             transformations: vec![ast::LhsTransformations::Any],
         },
-        rhs: Value::String("".to_string()),
+        rhs: ast::PredicateRhs::Value(Value::String("".to_string())),
         op: BinaryOperator::Postfix,
     };
 
@@ -378,7 +391,7 @@ fn test_predicate() {
             var_name: "my_key".to_string(),
             transformations: vec![ast::LhsTransformations::Any],
         },
-        rhs: Value::String("".to_string()),
+        rhs: ast::PredicateRhs::Value(Value::String("".to_string())),
         op: BinaryOperator::Prefix,
     };
 
@@ -390,7 +403,7 @@ fn test_predicate() {
             var_name: "my_key".to_string(),
             transformations: vec![ast::LhsTransformations::Any],
         },
-        rhs: Value::String("ob".to_string()),
+        rhs: ast::PredicateRhs::Value(Value::String("ob".to_string())),
         op: BinaryOperator::Contains,
     };
 
@@ -402,9 +415,36 @@ fn test_predicate() {
             var_name: "my_key".to_string(),
             transformations: vec![ast::LhsTransformations::Any],
         },
-        rhs: Value::String("ok".to_string()),
+        rhs: ast::PredicateRhs::Value(Value::String("ok".to_string())),
         op: BinaryOperator::Contains,
     };
 
     assert!(!p.execute(&mut ctx, &mut mat));
+
+    ctx.reset();
+
+    let missing = Predicate {
+        lhs: ast::Lhs {
+            var_name: "my_key".to_string(),
+            transformations: vec![],
+        },
+        rhs: ast::PredicateRhs::Missing,
+        op: BinaryOperator::Equals,
+    };
+
+    assert!(missing.execute(&ctx, &mut mat));
+
+    ctx.add_value("my_key", Value::String("present".to_string()));
+    assert!(!missing.execute(&ctx, &mut mat));
+
+    let present = Predicate {
+        lhs: ast::Lhs {
+            var_name: "my_key".to_string(),
+            transformations: vec![],
+        },
+        rhs: ast::PredicateRhs::Missing,
+        op: BinaryOperator::NotEquals,
+    };
+
+    assert!(present.execute(&ctx, &mut mat));
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -1,7 +1,8 @@
 extern crate pest;
 
 use crate::ast::{
-    BinaryOperator, Expression, Lhs, LhsTransformations, LogicalExpression, Predicate, Value,
+    BinaryOperator, Expression, Lhs, LhsTransformations, LogicalExpression, Predicate,
+    PredicateRhs, Value,
 };
 use cidr::{IpCidr, Ipv4Cidr, Ipv6Cidr};
 use pest::error::Error as ParseError;
@@ -14,6 +15,11 @@ use regex::Regex;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
 type ParseResult<T> = Result<T, ParseError<Rule>>;
+
+enum ParsedRhs {
+    Value(Value),
+    Nil,
+}
 
 /// cbindgen:ignore
 // Bug: https://github.com/eqrion/cbindgen/issues/286
@@ -95,20 +101,29 @@ fn parse_lhs(pair: Pair<Rule>) -> ParseResult<Lhs> {
     })
 }
 
-// rhs = { str_literal | ip_literal | int_literal }
+// rhs = { str_literal | ip_literal | int_literal | nil_literal }
 #[allow(clippy::result_large_err)] // it's fine as parsing is not the hot path
-fn parse_rhs(pair: Pair<Rule>) -> ParseResult<Value> {
+fn parse_rhs(pair: Pair<Rule>) -> ParseResult<ParsedRhs> {
     let pairs = pair.into_inner();
     let pair = pairs.peek().unwrap();
     let rule = pair.as_rule();
     Ok(match rule {
-        Rule::str_literal => Value::String(parse_str_literal(pair)?),
-        Rule::rawstr_literal => Value::String(parse_rawstr_literal(pair)?),
-        Rule::ipv4_cidr_literal => Value::IpCidr(IpCidr::V4(parse_ipv4_cidr_literal(pair)?)),
-        Rule::ipv6_cidr_literal => Value::IpCidr(IpCidr::V6(parse_ipv6_cidr_literal(pair)?)),
-        Rule::ipv4_literal => Value::IpAddr(IpAddr::V4(parse_ipv4_literal(pair)?)),
-        Rule::ipv6_literal => Value::IpAddr(IpAddr::V6(parse_ipv6_literal(pair)?)),
-        Rule::int_literal => Value::Int(parse_int_literal(pair)?),
+        Rule::str_literal => ParsedRhs::Value(Value::String(parse_str_literal(pair)?)),
+        Rule::rawstr_literal => ParsedRhs::Value(Value::String(parse_rawstr_literal(pair)?)),
+        Rule::ipv4_cidr_literal => {
+            ParsedRhs::Value(Value::IpCidr(IpCidr::V4(parse_ipv4_cidr_literal(pair)?)))
+        }
+        Rule::ipv6_cidr_literal => {
+            ParsedRhs::Value(Value::IpCidr(IpCidr::V6(parse_ipv6_cidr_literal(pair)?)))
+        }
+        Rule::ipv4_literal => {
+            ParsedRhs::Value(Value::IpAddr(IpAddr::V4(parse_ipv4_literal(pair)?)))
+        }
+        Rule::ipv6_literal => {
+            ParsedRhs::Value(Value::IpAddr(IpAddr::V6(parse_ipv6_literal(pair)?)))
+        }
+        Rule::int_literal => ParsedRhs::Value(Value::Int(parse_int_literal(pair)?)),
+        Rule::nil_literal => ParsedRhs::Nil,
         _ => unreachable!(),
     })
 }
@@ -212,28 +227,31 @@ fn parse_predicate(pair: Pair<Rule>) -> ParseResult<Predicate> {
     let rhs = parse_rhs(rhs_pair.clone())?;
     Ok(Predicate {
         lhs,
-        rhs: if op == BinaryOperator::Regex {
-            let Value::String(s) = rhs else {
-                return Err(ParseError::new_from_span(
-                    ErrorVariant::CustomError {
-                        message: "regex operator can only be used with String operands".to_string(),
-                    },
-                    rhs_pair.as_span(),
-                ));
-            };
+        rhs: match rhs {
+            ParsedRhs::Nil => PredicateRhs::Missing,
+            ParsedRhs::Value(rhs) if op == BinaryOperator::Regex => {
+                let Value::String(s) = rhs else {
+                    return Err(ParseError::new_from_span(
+                        ErrorVariant::CustomError {
+                            message: "regex operator can only be used with String operands"
+                                .to_string(),
+                        },
+                        rhs_pair.as_span(),
+                    ));
+                };
 
-            let r = Regex::new(&s).map_err(|e| {
-                ParseError::new_from_span(
-                    ErrorVariant::CustomError {
-                        message: e.to_string(),
-                    },
-                    rhs_pair.as_span(),
-                )
-            })?;
+                let r = Regex::new(&s).map_err(|e| {
+                    ParseError::new_from_span(
+                        ErrorVariant::CustomError {
+                            message: e.to_string(),
+                        },
+                        rhs_pair.as_span(),
+                    )
+                })?;
 
-            Value::Regex(r)
-        } else {
-            rhs
+                PredicateRhs::Value(Value::Regex(r))
+            }
+            ParsedRhs::Value(rhs) => PredicateRhs::Value(rhs),
         },
         op,
     })

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -1,4 +1,4 @@
-use crate::ast::{BinaryOperator, Expression, LogicalExpression, Type, Value};
+use crate::ast::{BinaryOperator, Expression, LogicalExpression, PredicateRhs, Type, Value};
 use crate::schema::Schema;
 use std::collections::HashMap;
 
@@ -76,6 +76,8 @@ const MSG_ONLY_FOR_INT: &str =
     "Greater/GreaterOrEqual/Less/LessOrEqual operators only supports integer operands";
 const MSG_ONLY_FOR_CIDR: &str = "In/NotIn operators only supports IP in CIDR";
 const MSG_CONTAINS_ONLY_FOR_CIDR: &str = "Contains operator only supports string operands";
+const MSG_NIL_ONLY_FOR_EQUALS: &str = "nil checks only support == and != operators";
+const MSG_NIL_NO_TRANSFORMATIONS: &str = "nil checks do not support lhs transformations";
 
 impl Validate for Expression {
     fn validate(&self, schema: &Schema) -> ValidationResult {
@@ -107,15 +109,30 @@ impl Validate for Expression {
                     return raise_err(MSG_UNKNOWN_LHS);
                 };
 
+                let (lower, any) = p.lhs.get_transformations();
+
+                if matches!(p.rhs, PredicateRhs::Missing) {
+                    if lower || any {
+                        return raise_err(MSG_NIL_NO_TRANSFORMATIONS);
+                    }
+
+                    return match p.op {
+                        Equals | NotEquals => Ok(()),
+                        _ => raise_err(MSG_NIL_ONLY_FOR_EQUALS),
+                    };
+                }
+
+                let PredicateRhs::Value(rhs) = &p.rhs else {
+                    unreachable!();
+                };
+
                 if p.op != Regex // Regex RHS is always Regex, and LHS is always String
                     && p.op != In // In/NotIn supports IPAddr in IpCidr
                     && p.op != NotIn
-                    && lhs_type != &p.rhs.my_type()
+                    && lhs_type != &rhs.my_type()
                 {
                     return raise_err(MSG_TYPE_MISMATCH_LHS_RHS);
                 }
-
-                let (lower, _any) = p.lhs.get_transformations();
 
                 // LHS transformations only makes sense with string fields
                 if lower && lhs_type != &Type::String {
@@ -131,22 +148,22 @@ impl Validate for Expression {
                             _ => raise_err(MSG_REGEX_ONLY_FOR_STRING),
                         }
                     }
-                    Prefix | Postfix => match p.rhs {
+                    Prefix | Postfix => match rhs {
                         Value::String(_) => Ok(()),
                         _ => raise_err(MSG_PREFIX_POSTFIX_ONLY_FOR_STRING),
                     },
-                    Greater | GreaterOrEqual | Less | LessOrEqual => match p.rhs {
+                    Greater | GreaterOrEqual | Less | LessOrEqual => match rhs {
                         Value::Int(_) => Ok(()),
                         _ => raise_err(MSG_ONLY_FOR_INT),
                     },
                     In | NotIn => {
                         // unchecked path above
-                        match (lhs_type, &p.rhs) {
+                        match (lhs_type, rhs) {
                             (Type::IpAddr, Value::IpCidr(_)) => Ok(()),
                             _ => raise_err(MSG_ONLY_FOR_CIDR),
                         }
                     }
-                    Contains => match p.rhs {
+                    Contains => match rhs {
                         Value::String(_) => Ok(()),
                         _ => raise_err(MSG_CONTAINS_ONLY_FOR_CIDR),
                     },
@@ -186,6 +203,8 @@ mod tests {
         let tests = vec![
             r#"string == "abc""#,
             r#"string != "abc""#,
+            r#"string == nil"#,
+            r#"string != nil"#,
             r#"string ~ "abc""#,
             r#"string ^= "abc""#,
             r#"string =^ "abc""#,
@@ -201,6 +220,9 @@ mod tests {
             r#"string == 192.168.0.0/24"#,
             r#"string == 123"#,
             r#"string in "abc""#,
+            r#"string > nil"#,
+            r#"lower(string) == nil"#,
+            r#"any(string) == nil"#,
         ];
         for input in failing_tests {
             let expression = parse(input).unwrap();


### PR DESCRIPTION
## Summary
- add a POC `nil` literal to the ATC grammar
- interpret `field == nil` / `field != nil` as missing/present checks for schema-known fields
- reject nil checks on transformed LHS values and keep other operators unchanged
- cover the new behavior in parser/display, semantic validation, and interpreter tests

## Testing
- cargo test

## Notes
- this POC models `nil` as field absence, not as a first-class typed value
- the current prototype changes the public Rust AST shape; a more compatibility-first alternative would be to keep `Predicate.rhs: Value` and add `Value::Nil`, then lower nil checks internally during validation/execution
- the AST changes here are intentionally scoped for the prototype and may need revisiting if the project later adds true nullable field types

## Run demo locally

```
cargo build
```
\<variable> != nil
```
resty -e '
  package.path = "./lib/?.lua;./lib/?/init.lua;" .. package.path
  package.cpath = "./target/debug/?.dylib;" .. package.cpath

  local schema = require("resty.router.schema")
  local router = require("resty.router.router")
  local context = require("resty.router.context")

  local s = schema.new()
  assert(s:add_field("http.path", "String"))

  local r = router.new(s)
  assert(r:add_matcher(
    0,
    "a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c",
    "http.path != nil"
  ))

  local c = context.new(s)

  assert(c:add_value("http.path", nil))
  ngx.say("missing -> ", r:execute(c))

  c:reset()
  assert(c:add_value("http.path", "/foo"))
  ngx.say("present -> ", r:execute(c))
  '
```
\<variable> == nil
```
resty -e '
  package.path = "./lib/?.lua;./lib/?/init.lua;" .. package.path
  package.cpath = "./target/debug/?.dylib;" .. package.cpath

  local schema = require("resty.router.schema")
  local router = require("resty.router.router")
  local context = require("resty.router.context")

  local s = schema.new()
  assert(s:add_field("http.path", "String"))

  local r = router.new(s)
  assert(r:add_matcher(
    0,
    "a921a9aa-ec0e-4cf3-a6cc-1aa5583d150c",
    "http.path == nil"
  ))

  local c = context.new(s)

  -- nil means "field not added to context"
  assert(c:add_value("http.path", nil))
  ngx.say("missing -> ", r:execute(c))

  c:reset()
  assert(c:add_value("http.path", "/foo"))
  ngx.say("present -> ", r:execute(c))
  '
```