### PR TITLE
fix(lint): allow multiple_crate_versions clippy lint

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,9 @@
 #![deny(warnings, missing_debug_implementations)]
+// Transitive dev-dependencies (e.g. criterion vs. pest_derive) can pull in
+// two major versions of a proc-macro crate like `syn` independently of any
+// change here; this isn't something a single PR controls, so don't let it
+// fail the build.
+#![allow(clippy::multiple_crate_versions)]
 /*!
 This crate provides a powerful rule based matching engine that can match a set of routes
 against dynamic input value efficiently.


### PR DESCRIPTION
## Summary

- `src/lib.rs` has `#![deny(warnings, missing_debug_implementations)]`, which promotes clippy's `multiple_crate_versions` lint from a warning to a hard build error whenever the resolved dependency graph contains two major versions of the same transitive crate.
- Since this repo doesn't commit `Cargo.lock`, every CI run resolves fresh against crates.io. `serde_derive` (pulled in via the `criterion` dev-dependency) recently started requiring `syn = "^3"`, while `pest_derive` (a direct dependency) still resolves to `syn 2.x` — so the graph now always contains both majors, independent of any change in a given PR. This broke the [Rust Clippy Report](https://github.com/Kong/atc-router/runs/94371856315) check on #341.
- This lint is about the whole transitive graph, which a single PR doesn't control and can drift at any time as upstream crates release new versions. Add an explicit `#[allow(...)]` for it instead of failing the build on ecosystem churn.

## Test plan

- [x] `cargo clippy --manifest-path ./Cargo.toml -- -W clippy::correctness -W clippy::cargo -W clippy::suspicious -W clippy::style` locally: no more `multiple_crate_versions` error (only the two pre-existing, unrelated `needless_borrow` style warnings remain)
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)